### PR TITLE
83 disable directionality when fluttering is selected

### DIFF
--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -859,6 +859,32 @@ class MovementTreeModel(QStandardItemModel):
             # (2) it was unchecked as a (previously partially-checked) ancestor of a user-unchecked node, or
             # (3) it was force-unchecked as a result of ME/sibling interaction
             item.uncheck(force=False)
+        self.check_dependencies(item)
+
+    def check_dependencies(self, item):
+        '''
+        Disable directionality if Wiggling/Fluttering is selected
+        '''
+        warning = None
+
+        if(item.text()=="Wiggling/Fluttering"):
+            itemstate = item.checkState()
+            uni = self.findItems("Unidirectional", flags = Qt.MatchRecursive)[0]
+            bi = self.findItems("Bidirectional", flags = Qt.MatchRecursive)[0]
+            dir = self.findItems("Directionality", flags = Qt.MatchRecursive)[0]
+
+
+            if (itemstate == Qt.Checked): # disable directionality options as mvmt is inherently bidirectional
+                dir.setEnabled(False)
+                uni.setEnabled(False)
+                bi.setEnabled(False)
+            elif (itemstate == Qt.Unchecked):
+                dir.setEnabled(True)
+                uni.setEnabled(True)
+                bi.setEnabled(True)
+
+
+
 
     def populate(self, parentnode, structure={}, pathsofar="", issubgroup=False, isfinalsubgroup=True, subgroupname=""):
         if structure == {} and pathsofar != "":
@@ -903,6 +929,8 @@ class MovementTreeModel(QStandardItemModel):
                             thistreenode.setData(isfinalsubgroup, role=Qt.UserRole + udr.finalsubgrouprole)
                     self.populate(thistreenode, structure=structure[labelclassifierchecked_5tuple], pathsofar=pathsofar+label+delimiter)
                     parentnode.appendRow([thistreenode, editablepart])
+
+
 
     @property
     def listmodel(self):

--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -874,6 +874,9 @@ class MovementTreeModel(QStandardItemModel):
                 dir.setEnabled(False)
                 uni.setEnabled(False)
                 bi.setEnabled(False)
+                uni.setCheckState(Qt.Unchecked)
+                bi.setCheckState(Qt.Unchecked)
+                dir.setCheckState(Qt.Unchecked)
             elif (itemstate == Qt.Unchecked):
                 dir.setEnabled(True)
                 uni.setEnabled(True)

--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -16,12 +16,8 @@ from PyQt5.Qt import (
 from PyQt5.QtWidgets import (
     QMessageBox
 )
-from PyQt5.QtGui import (
-    QColor
-)
 
 from lexicon.module_classes import userdefinedroles as udr, delimiter, AddedInfo
-import logging
 
 # for backwards compatibility
 specifytotalcycles_str = "Specify total number of cycles"

--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -16,9 +16,12 @@ from PyQt5.Qt import (
 from PyQt5.QtWidgets import (
     QMessageBox
 )
+from PyQt5.QtGui import (
+    QColor
+)
 
 from lexicon.module_classes import userdefinedroles as udr, delimiter, AddedInfo
-
+import logging
 
 # for backwards compatibility
 specifytotalcycles_str = "Specify total number of cycles"
@@ -865,14 +868,11 @@ class MovementTreeModel(QStandardItemModel):
         '''
         Disable directionality if Wiggling/Fluttering is selected
         '''
-        warning = None
-
         if(item.text()=="Wiggling/Fluttering"):
             itemstate = item.checkState()
             uni = self.findItems("Unidirectional", flags = Qt.MatchRecursive)[0]
             bi = self.findItems("Bidirectional", flags = Qt.MatchRecursive)[0]
             dir = self.findItems("Directionality", flags = Qt.MatchRecursive)[0]
-
 
             if (itemstate == Qt.Checked): # disable directionality options as mvmt is inherently bidirectional
                 dir.setEnabled(False)
@@ -882,8 +882,6 @@ class MovementTreeModel(QStandardItemModel):
                 dir.setEnabled(True)
                 uni.setEnabled(True)
                 bi.setEnabled(True)
-
-
 
 
     def populate(self, parentnode, structure={}, pathsofar="", issubgroup=False, isfinalsubgroup=True, subgroupname=""):


### PR DESCRIPTION
Directionality and its suboptions are disabled/enabled when Wiggling/Fluttering is selected/deselected, as requested. However, for some reason the suboptions don't get greyed out even though they are disabled:
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/55113760/433a00c9-4f2f-44fa-bb1b-60eacec8a305)

I tried `QStandardItem.setForeground()` to manually set the text color to gray, but this didn't work either. It might be a problem with the style for radio buttons, since I was able to use `setForeground()` successfully with all the checkboxes in the movement tree, but none of the radio buttons. 

Should I continue trying to find a way to grey out the suboptions, or is it okay as is?
