### PR TITLE
Add 'fully rotating' option to joint-specific options of movement tree

### DIFF
--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -134,6 +134,12 @@ mvmtOptionsDict = {
                     ("Supination", fx, rb, u, 59): {}  # TODO KV autofills to Proximal radioulnar supination
                 }
             },
+            ("Fully rotating", fx, rb, u, 56): {
+                (subgroup, None, 0, None, 57): {
+                    ("Ulnar → nodding → supination → radial → un-nodding", fx, rb, u, 58): {}, 
+                    ("Radial → nodding → pronation → ulnar → un-nodding", fx, rb, u, 59): {}  
+                }
+            },
             ("Closing/Opening", fx, rb, u, 60): {
                 (subgroup, None, 0, None, 61): {
                     ("Closing", fx, rb, u, 62): {},  # TODO KV autofills to flexion of [selected finger, all joints]


### PR DESCRIPTION
- I haven't assigned unique values for the unused `node_id` key of these new options as it would mean updating the values for a hundred or so more options below in the movement tree. Since they're just placeholders for now, I hope that's okay. (You've probably thought more about this, but if we want ordered unique ids for the tree nodes, maybe they could be assigned during the tree traversal in `populate()` instead of hardcoding the numbers?) 
- Added the new options to section 1.2 of the internal documentation. 