### PR TITLE
150 sign level information compound sign checkbox does not save properly

### DIFF
--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -337,6 +337,7 @@ class MainWindow(QMainWindow):
             self.corpus.name = newtitle
 
     # TODO KV this needs an overhaul
+    # GZ - missing compound sign attribute
     def on_action_export_handshape_transcription_csv(self):
         export_csv_dialog = ExportCSVDialog(self.app_settings, parent=self)
         if export_csv_dialog.exec_():

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -156,6 +156,7 @@ class SignLevelInformation:
             self._note = serializedsignlevelinfo['note']
             # backward compatibility for attribute added 20230412!
             self._fingerspelled = 'fingerspelled' in serializedsignlevelinfo.keys() and serializedsignlevelinfo['fingerspelled']
+            self._compoundsign = 'compoundsign' in serializedsignlevelinfo.keys() and serializedsignlevelinfo['compoundsign']
             self._handdominance = serializedsignlevelinfo['handdominance']
         elif signlevel_info is not None:
             self._entryid = signlevel_info['entryid']
@@ -170,6 +171,7 @@ class SignLevelInformation:
             self._note = signlevel_info['note']
             # backward compatibility for attribute added 20230412!
             self._fingerspelled = 'fingerspelled' in signlevel_info.keys() and signlevel_info['fingerspelled']
+            self._compoundsign = 'compoundsign' in signlevel_info.keys() and signlevel_info['compoundsign']
             self._handdominance = signlevel_info['handdominance']
         else:
             print("TODO KV no sign level info; what to do?")
@@ -202,6 +204,7 @@ class SignLevelInformation:
             'date last modified': self._datelastmodified.timestamp(),
             'note': self._note,
             'fingerspelled': self._fingerspelled,
+            'compoundsign': self._compoundsign,
             'handdominance': self._handdominance
         }
 
@@ -236,6 +239,14 @@ class SignLevelInformation:
     @fingerspelled.setter
     def fingerspelled(self, new_fingerspelled):
         self._fingerspelled = new_fingerspelled
+
+    @property
+    def compoundsign(self):
+        return self._compoundsign
+    
+    @compoundsign.setter
+    def compoundsign(self, new_compoundsign):
+        self._compoundsign = new_compoundsign
 
     @property
     def source(self):

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -187,6 +187,8 @@ class SignLevelInformation:
                 aresame = False
             if self._note != other.note or self._fingerspelled != other.fingerspelled or self._handdominance != other.handdominance:
                 aresame = False
+            if self._compoundsign != other.compoundsign:
+                aresame = False
         else:
             aresame = False
         return aresame


### PR DESCRIPTION
Added code for `compoundsign` everywhere I could see that it was missing, except for the `on_action_export_handshape_transcription` method in in `main_window.py`. I saw that the method might be overhauled later so I just left a comment, but let me know if I should add the `compoundsign` code.