### PR TITLE
Collapse 'other hand>whole hand' option into 'other hand' option

### DIFF
--- a/src/main/python/models/location_models.py
+++ b/src/main/python/models/location_models.py
@@ -351,12 +351,12 @@ class LocationTreeModel(QStandardItemModel):
         dicts = [self.serializedlocntree.checkstates, self.serializedlocntree.addedinfos, self.serializedlocntree.detailstables]
 
         # As of 20230631, entries with "other hand>whole hand" will be moved to "other hand" with surfaces and subareas preserved
-        if ("Other hand>Whole hand" in self.serializedlocntree.checkstates):
-            if (self.serializedlocntree.checkstates["Other hand>Whole hand"] == Qt.Checked):
+        if ("Other hand"+delimiter+"Whole hand" in self.serializedlocntree.checkstates):
+            if (self.serializedlocntree.checkstates["Other hand"+delimiter+"Whole hand"] == Qt.Checked):
                 for stored_dict in dicts:
-                    stored_dict["Other hand"] = stored_dict["Other hand>Whole hand"] 
+                    stored_dict["Other hand"] = stored_dict["Other hand"+delimiter+"Whole hand"] 
             for stored_dict in dicts:
-                stored_dict.pop("Other hand>Whole hand")
+                stored_dict.pop("Other hand"+delimiter+"Whole hand")
 
         for stored_dict in dicts:
             pairstoadd = {}


### PR DESCRIPTION
- If a location module was saved with `Other hand` selected, leave it alone
- If a location module was saved with `Other hand>Whole hand` selected, rename it as `Other hand` and carry over its surfaces/subareas
- If a location module was saved with both `Other hand` and `Other hand>Whole hand` selected:
  - Replace the former with the latter and carry over the surfaces/subareas

The backward compatibility is handled differently for this change, since it's a replacement with an existing option instead of with an entirely new option.  