### PR TITLE
179 bug missing joint specific movements after 175178

### DIFF
--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -931,8 +931,6 @@ class MovementTreeModel(QStandardItemModel):
                 treechild = treenode.child(r, 0)
                 if treechild is not None:
                     pathtext = treechild.data(Qt.UserRole + udr.pathdisplayrole)
-                    if pathtext.endswith("Trilled") or pathtext.endswith("Twisting"):
-                        print("temp", pathtext, "checkstate", self.serializedmvmttree.checkstates[pathtext])
                     if pathtext in self.serializedmvmttree.checkstates.keys():
                         treechild.setCheckState(self.serializedmvmttree.checkstates[pathtext])
 

--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -610,9 +610,10 @@ class MovementTreeItem(QStandardItem):
 
     def setEnabledRecursive(self, enable):
         self.setEnabled(enable)
+        if not enable:
+            self.uncheck()
         if self.data(Qt.UserRole+udr.isuserspecifiablerole) != fx:
             self.editablepart().setEnabled(enable)
-        self.setCheckState(Qt.Unchecked)
 
         for r in range(self.rowCount()):
             self.child(r, 0).setEnabledRecursive(enable)
@@ -930,6 +931,8 @@ class MovementTreeModel(QStandardItemModel):
                 treechild = treenode.child(r, 0)
                 if treechild is not None:
                     pathtext = treechild.data(Qt.UserRole + udr.pathdisplayrole)
+                    if pathtext.endswith("Trilled") or pathtext.endswith("Twisting"):
+                        print("temp", pathtext, "checkstate", self.serializedmvmttree.checkstates[pathtext])
                     if pathtext in self.serializedmvmttree.checkstates.keys():
                         treechild.setCheckState(self.serializedmvmttree.checkstates[pathtext])
 


### PR DESCRIPTION
Uncheck only when disabling. The only potential pitfall of this is that when we re-enable, if there is an "other" specification then that item will get auto-checked (even if it wasn't before).