### PR TITLE
Entering into edit state is disabled on Corpus panel

### DIFF
--- a/src/main/python/gui/corpus_view.py
+++ b/src/main/python/gui/corpus_view.py
@@ -11,7 +11,8 @@ from PyQt5.QtWidgets import (
     QListView,
     QVBoxLayout,
     QHBoxLayout,
-    QComboBox
+    QComboBox,
+    QAbstractItemView
 )
 
 from models.corpus_models import CorpusModel, CorpusSortProxyModel
@@ -55,6 +56,7 @@ class CorpusDisplay(QWidget):
         # self.corpus_view.setModel(self.corpus_model)
         self.corpus_view.setModel(self.corpus_sortproxy)
         self.corpus_view.clicked.connect(self.handle_selection)
+        self.corpus_view.setEditTriggers(QAbstractItemView.NoEditTriggers)  # disable edit by double-clicking an item
 
         # Corpus filter by gloss
         self.corpus_filter_input = QLineEdit()


### PR DESCRIPTION
Previously, double-clicking an item of the Corpus list appeared as if the user could change sign info. This could be misleading because it does nothing actually. 

This commit uses QAbstractItemView.NoEditTriggers to ignore a double click (and on Mac, hitting Return).