### PR TITLE
Don't panic if the user cancels out of the load dialog!!

### DIFF
--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -876,6 +876,9 @@ class MainWindow(QMainWindow):
                                                            self.tr('Open Corpus'),
                                                            self.app_settings['storage']['recent_folder'],
                                                            self.tr('SLP-AA Corpus (*.slpaa)'))
+        if not file_name:
+            # the user cancelled out of the dialog
+            return False
         folder, _ = os.path.split(file_name)
         if folder:
             self.app_settings['storage']['recent_folder'] = folder
@@ -890,7 +893,7 @@ class MainWindow(QMainWindow):
             self.signsummary_panel.refreshsign(None)
             self.signlevel_panel.clear()
             self.signlevel_panel.enable_module_buttons(False)
-            
+
 
         return self.corpus is not None  # bool(Corpus)
 


### PR DESCRIPTION
SLPAA internally throws an error if the user tries to load a corpus and then cancels out of the dialog (issue #229). This simple PR adds a conditional that catches this behaviour and stops the load function.

It seems simple, but please double-check to ensure I covered all use case scenarios.