### PR TITLE
Restore Defaults for HandConfig module

### DIFF
--- a/src/main/python/gui/handconfigspecification_view.py
+++ b/src/main/python/gui/handconfigspecification_view.py
@@ -1111,6 +1111,7 @@ class HandConfigSpecificationPanel(ModuleSpecificationPanel):
 
     def clear(self):
         self.panel.clear()
+        self.illustration.set_neutral_img()
 
     def desiredwidth(self):
         return 2000


### PR DESCRIPTION
Issue #70

Added a line to the clear function that now allows restore defaults to clear the illustration panel as well.

Before restore defaults:
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/51172655/906141ec-d018-4590-b4e7-1a4c4e531662)

After restore defaults:
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/51172655/3cd94605-22e8-4b4c-8eaf-f8fbe6acf5a7)
