### PR TITLE
238 side script counting x slots

### DIFF
--- a/src/main/python/gui/countxslots_dialog.py
+++ b/src/main/python/gui/countxslots_dialog.py
@@ -1,0 +1,154 @@
+import io
+
+from PyQt5.QtWidgets import (
+    QVBoxLayout,
+    QDialog,
+    QPushButton,
+    QLabel,
+    QComboBox,
+    QFormLayout,
+    QFrame,
+    QDialogButtonBox,
+    QFileDialog
+)
+
+
+class CountXslotsDialog(QDialog):
+
+    def __init__(self, app_settings, app_ctx, **kwargs):
+        super().__init__(**kwargs)
+        self.app_settings = app_settings
+        self.filenames = []
+        self.outputformat = "csv"
+
+        main_layout = QVBoxLayout()
+        form_layout = QFormLayout()
+
+        self.choosefileslabel = QLabel("1. Choose the .slpaa corpus file(s) whose signs to analyze.")
+        self.choosefilesbutton = QPushButton("Select file(s)")
+        self.choosefilesbutton.clicked.connect(self.handle_select_files)
+        form_layout.addRow(self.choosefileslabel, self.choosefilesbutton)
+        self.selectformatlabel = QLabel("2. Choose whether you'd like the results in comma-separated (.csv) or tab-delimited (.txt) format.")
+        self.selectformatcombo = QComboBox()
+        self.selectformatcombo.addItems(["Comma (.csv)", "Tab (.txt)"])
+        self.selectformatcombo.currentTextChanged.connect(self.combotext_changed)
+        form_layout.addRow(self.selectformatlabel, self.selectformatcombo)
+        self.countxslotslabel = QLabel("3. Count x-slots for each sign in selected file(s).\nResults for each corpus will be saved in the same location as the original .slpaa file.")
+        self.countxslotsbutton = QPushButton("Count x-slots")
+        self.countxslotsbutton.clicked.connect(self.handle_count_xslots)
+        form_layout.addRow(self.countxslotslabel, self.countxslotsbutton)
+        self.statuslabel = QLabel("4. Status of x-slot counter:")
+        self.statusdisplay = StatusDisplay("not yet attempted")
+        form_layout.addRow(self.statuslabel, self.statusdisplay)
+
+        main_layout.addLayout(form_layout)
+
+        horizontal_line = QFrame()
+        horizontal_line.setFrameShape(QFrame.HLine)
+        horizontal_line.setFrameShadow(QFrame.Sunken)
+        main_layout.addWidget(horizontal_line)
+
+        buttons = QDialogButtonBox.Close
+        self.button_box = QDialogButtonBox(buttons, parent=self)
+        self.button_box.clicked.connect(self.handle_buttonbox_click)
+        main_layout.addWidget(self.button_box)
+
+        self.setLayout(main_layout)
+
+    def combotext_changed(self, txt):
+        if "comma" in txt:
+            newoutputformat = "csv"
+        else:  # "tab"
+            newoutputformat = "txt"
+
+        if newoutputformat != self.outputformat:
+            self.statusdisplay.setText(newoutputformat + " format selected")
+        self.outputformat = newoutputformat
+
+    def handle_select_files(self):
+        file_names, file_type = QFileDialog.getOpenFileNames(self,
+                                                            self.tr('Select Corpus'),
+                                                            self.app_settings['storage']['recent_folder'],
+                                                            self.tr('SLP-AA Corpus (*.slpaa)'))
+        if file_names != self.filenames:
+            numfiles = len(file_names)
+            self.statusdisplay.setText(str(numfiles) + " file" + ("" if numfiles == 1 else "s") + " selected")
+        self.filenames = file_names
+
+    def handle_count_xslots(self):
+
+        self.statusdisplay.setText("counting...")
+        self.count_all_xslots()
+
+    def count_all_xslots(self):
+
+        badformatlist = []
+        failedtoloadlist = []
+        successlist = []
+        failurelist = []
+        for corpusfilepath in self.filenames:
+            if not corpusfilepath.endswith(".slpaa"):
+                badformatlist.append(corpusfilepath)
+            else:
+                corpus = self.parent().load_corpus_binary(corpusfilepath)
+                if corpus is None:
+                    failedtoloadlist.append(corpusfilepath)
+                else:
+                    resultsfilepath = corpusfilepath.replace(".slpaa", "_xslotcounts." + self.outputformat)
+                    result = self.count_record_corpus_xslots(corpus, resultsfilepath)
+                    if result == "success":
+                        successlist.append(resultsfilepath)
+                    else:
+                        failurelist.append(corpusfilepath + " (permission error)")
+
+        statusstrings = []
+        if len(badformatlist) > 0:
+            badformatnames = [self.getfilenamefrompath(fp) for fp in badformatlist]
+            statusstrings.append("incorrect format: " + ",\n\t".join(badformatnames))
+        if len(failedtoloadlist) > 0:
+            failedtoloadnames = [self.getfilenamefrompath(fp) for fp in failedtoloadlist]
+            statusstrings.append("failed to load: " + ",\n\t".join(failedtoloadnames))
+        if len(failurelist) > 0:
+            failurenames = [self.getfilenamefrompath(fp) for fp in failurelist]
+            statusstrings.append("failed to count: " + ",\n\t".join(failurenames))
+        if len(successlist) > 0:
+            successnames = [self.getfilenamefrompath(fp) for fp in successlist]
+            statusstrings.append("successful results: " + ",\n\t".join(successnames))
+
+        self.statusdisplay.setText("\n".join(statusstrings))
+
+    def getfilenamefrompath(self, filepath):
+        afterlastslash = filepath.rfind("/") + 1
+        return filepath[afterlastslash:]
+
+    def count_record_corpus_xslots(self, corpus, resultsfilepath):
+        d = "," if self.outputformat == "csv" else "\t"
+        try:
+            with io.open(resultsfilepath, "w") as rfile:
+                rfile.write(d.join(["gloss", "whole_xslots", "partial_xslots", "fingerspelled"]) + "\n")
+                for sign in corpus.signs:
+                    gloss = sign.signlevel_information.gloss
+                    whole_xslots = sign.xslotstructure.number
+                    frac_xslots = sign.xslotstructure.additionalfraction
+                    fingerspelled = sign.signlevel_information.fingerspelled
+                    rfile.write(d.join([gloss, str(whole_xslots), str(frac_xslots), str(fingerspelled)]) + "\n")
+            return "success"
+        except PermissionError:
+            return "permission error"
+        except:
+            return "unspecified error"
+
+    def handle_buttonbox_click(self, button):
+        standard = self.button_box.standardButton(button)
+
+        if standard == QDialogButtonBox.Close:
+            # close dialog
+            self.accept()
+
+
+class StatusDisplay(QLabel):
+    def __init__(self, initialtext="", **kwargs):
+        super().__init__(**kwargs)
+        self.setText(initialtext)
+        self.setStyleSheet("border: 1px solid black;")
+

--- a/src/main/python/gui/countxslots_dialog.py
+++ b/src/main/python/gui/countxslots_dialog.py
@@ -18,26 +18,44 @@ class CountXslotsDialog(QDialog):
     def __init__(self, app_settings, app_ctx, **kwargs):
         super().__init__(**kwargs)
         self.app_settings = app_settings
-        self.filenames = []
+        self.corpusfilepaths = []
+        self.combinedresultsfilepath = ""
         self.outputformat = "csv"
+        self.combined = False
+
+        self.results_lists = {
+            "incorrect format": [],
+            "failed to load": [],
+            "failed to count": [],
+            "successful results": []
+        }
 
         main_layout = QVBoxLayout()
         form_layout = QFormLayout()
 
         self.choosefileslabel = QLabel("1. Choose the .slpaa corpus file(s) whose signs to analyze.")
-        self.choosefilesbutton = QPushButton("Select file(s)")
-        self.choosefilesbutton.clicked.connect(self.handle_select_files)
+        self.choosefilesbutton = QPushButton("Select corpus file(s)")
+        self.choosefilesbutton.clicked.connect(self.handle_select_corpusfiles)
         form_layout.addRow(self.choosefileslabel, self.choosefilesbutton)
         self.selectformatlabel = QLabel("2. Choose whether you'd like the results in comma-separated (.csv) or tab-delimited (.txt) format.")
         self.selectformatcombo = QComboBox()
         self.selectformatcombo.addItems(["Comma (.csv)", "Tab (.txt)"])
-        self.selectformatcombo.currentTextChanged.connect(self.combotext_changed)
+        self.selectformatcombo.currentTextChanged.connect(self.formatcombo_changed)
         form_layout.addRow(self.selectformatlabel, self.selectformatcombo)
-        self.countxslotslabel = QLabel("3. Count x-slots for each sign in selected file(s).\nResults for each corpus will be saved in the same location as the original .slpaa file.")
+        self.selectcombinedlabel = QLabel("3a. Choose whether you'd like each .slpaa file to have its own separate results file, or combine them all in one.")
+        self.selectcombinedcombo = QComboBox()
+        self.selectcombinedcombo.addItems(["Separate", "Combined"])
+        self.selectcombinedcombo.currentTextChanged.connect(self.combinedcombo_changed)
+        form_layout.addRow(self.selectcombinedlabel, self.selectcombinedcombo)
+        self.choosecombinedfilelabel = QLabel("3b. If combined, choose the name and location for the results file.")
+        self.choosecombinedfilebutton = QPushButton("Select results file")
+        self.choosecombinedfilebutton.clicked.connect(self.handle_select_resultsfile)
+        form_layout.addRow(self.choosecombinedfilelabel, self.choosecombinedfilebutton)
+        self.countxslotslabel = QLabel("4. Count x-slots for each sign in selected file(s).\nResults for each corpus will be saved in the same location as the original .slpaa file.")
         self.countxslotsbutton = QPushButton("Count x-slots")
         self.countxslotsbutton.clicked.connect(self.handle_count_xslots)
         form_layout.addRow(self.countxslotslabel, self.countxslotsbutton)
-        self.statuslabel = QLabel("4. Status of x-slot counter:")
+        self.statuslabel = QLabel("5. Status of x-slot counter:")
         self.statusdisplay = StatusDisplay("not yet attempted")
         form_layout.addRow(self.statuslabel, self.statusdisplay)
 
@@ -55,8 +73,14 @@ class CountXslotsDialog(QDialog):
 
         self.setLayout(main_layout)
 
-    def combotext_changed(self, txt):
-        if "comma" in txt:
+    def delim(self):
+        if self.outputformat == "csv":
+            return ","
+        else:
+            return "\t"
+
+    def formatcombo_changed(self, txt):
+        if "comma" in txt.lower():
             newoutputformat = "csv"
         else:  # "tab"
             newoutputformat = "txt"
@@ -65,78 +89,106 @@ class CountXslotsDialog(QDialog):
             self.statusdisplay.setText(newoutputformat + " format selected")
         self.outputformat = newoutputformat
 
-    def handle_select_files(self):
+    def combinedcombo_changed(self, txt):
+        if "combined" in txt.lower():
+            newcombined = True
+        else:  # "separate"
+            newcombined = False
+
+        if newcombined != self.combined:
+            self.statusdisplay.setText(txt + " selected")
+        self.combined = newcombined
+
+    def handle_select_corpusfiles(self):
         file_names, file_type = QFileDialog.getOpenFileNames(self,
                                                             self.tr('Select Corpus'),
                                                             self.app_settings['storage']['recent_folder'],
                                                             self.tr('SLP-AA Corpus (*.slpaa)'))
-        if file_names != self.filenames:
+        if file_names != self.corpusfilepaths:
             numfiles = len(file_names)
             self.statusdisplay.setText(str(numfiles) + " file" + ("" if numfiles == 1 else "s") + " selected")
-        self.filenames = file_names
+        self.corpusfilepaths = file_names
+
+    def handle_select_resultsfile(self):
+        description = "Comma-separated" if self.outputformat == "csv" else "Tab-separated"
+        extension = self.outputformat
+        file_name, file_type = QFileDialog.getSaveFileName(self,
+                                                           self.tr('Select results destination'),
+                                                           self.app_settings['storage']['recent_folder'],
+                                                           self.tr(description + "(*." + extension + ")"))
+        if file_name != self.combinedresultsfilepath:
+            self.statusdisplay.setText("destination selected")
+        self.combinedresultsfilepath = file_name
 
     def handle_count_xslots(self):
 
         self.statusdisplay.setText("counting...")
-        self.count_all_xslots()
+        self.clear_results_lists()
 
-    def count_all_xslots(self):
+        self.count_xslots()
 
-        badformatlist = []
-        failedtoloadlist = []
-        successlist = []
-        failurelist = []
-        for corpusfilepath in self.filenames:
+        statusstrings = []
+        for listname in self.results_lists.keys():
+            if len(self.results_lists[listname]) > 0:
+                filenames = [self.getfilenamefrompath(fp) for fp in self.results_lists[listname]]
+                statusstrings.append(listname + ":\n\t" + ",\n\t".join(filenames))
+        self.statusdisplay.setText("\n".join(statusstrings))
+
+    def clear_results_lists(self):
+        for k in self.results_lists.keys():
+            self.results_lists[k] = []
+
+    def count_xslots(self):
+        if self.combined:
+            resultsfilepath = self.combinedresultsfilepath
+            try:
+                with io.open(resultsfilepath, "w") as outfile:
+                    outfile.write(self.delim().join(["source_file", "gloss", "whole_xslots", "partial_xslots", "fingerspelled"]) + "\n")
+            except PermissionError:
+                return "permission error"
+            except:
+                return "unspecified error"
+            w_or_a = "a"
+        else:
+            w_or_a = "w"
+
+        for corpusfilepath in self.corpusfilepaths:
             if not corpusfilepath.endswith(".slpaa"):
-                badformatlist.append(corpusfilepath)
+                self.results_lists["incorrect format"].append(corpusfilepath)
             else:
                 corpus = self.parent().load_corpus_binary(corpusfilepath)
                 if corpus is None:
-                    failedtoloadlist.append(corpusfilepath)
+                    self.results_lists["failed to load"].append(corpusfilepath)
                 else:
-                    resultsfilepath = corpusfilepath.replace(".slpaa", "_xslotcounts." + self.outputformat)
-                    result = self.count_record_corpus_xslots(corpus, resultsfilepath)
+                    if not self.combined:
+                        resultsfilepath = corpusfilepath.replace(".slpaa", "_xslotcounts." + self.outputformat)
+                    result = self.count_record_corpus_xslots(corpus, self.getfilenamefrompath(corpusfilepath), resultsfilepath, w_or_a)
                     if result == "success":
-                        successlist.append(resultsfilepath)
+                        self.results_lists["successful results"].append(corpusfilepath)
                     else:
-                        failurelist.append(corpusfilepath + " (permission error)")
+                        self.results_lists["failed to load"].append(corpusfilepath + " (" + result + ")")
 
-        statusstrings = []
-        if len(badformatlist) > 0:
-            badformatnames = [self.getfilenamefrompath(fp) for fp in badformatlist]
-            statusstrings.append("incorrect format: " + ",\n\t".join(badformatnames))
-        if len(failedtoloadlist) > 0:
-            failedtoloadnames = [self.getfilenamefrompath(fp) for fp in failedtoloadlist]
-            statusstrings.append("failed to load: " + ",\n\t".join(failedtoloadnames))
-        if len(failurelist) > 0:
-            failurenames = [self.getfilenamefrompath(fp) for fp in failurelist]
-            statusstrings.append("failed to count: " + ",\n\t".join(failurenames))
-        if len(successlist) > 0:
-            successnames = [self.getfilenamefrompath(fp) for fp in successlist]
-            statusstrings.append("successful results: " + ",\n\t".join(successnames))
-
-        self.statusdisplay.setText("\n".join(statusstrings))
-
-    def getfilenamefrompath(self, filepath):
-        afterlastslash = filepath.rfind("/") + 1
-        return filepath[afterlastslash:]
-
-    def count_record_corpus_xslots(self, corpus, resultsfilepath):
-        d = "," if self.outputformat == "csv" else "\t"
+    def count_record_corpus_xslots(self, corpus, corpusfilename, resultsfilepath, write_or_append):
         try:
-            with io.open(resultsfilepath, "w") as rfile:
-                rfile.write(d.join(["gloss", "whole_xslots", "partial_xslots", "fingerspelled"]) + "\n")
+            with io.open(resultsfilepath, write_or_append) as outfile:
+                headers = ["source_file", "gloss", "whole_xslots", "partial_xslots", "fingerspelled"]
+                if not self.combined:
+                    outfile.write(self.delim().join(headers) + "\n")
                 for sign in corpus.signs:
                     gloss = sign.signlevel_information.gloss
                     whole_xslots = sign.xslotstructure.number
                     frac_xslots = sign.xslotstructure.additionalfraction
                     fingerspelled = sign.signlevel_information.fingerspelled
-                    rfile.write(d.join([gloss, str(whole_xslots), str(frac_xslots), str(fingerspelled)]) + "\n")
+                    outfile.write(self.delim().join([corpusfilename, gloss, str(whole_xslots), str(frac_xslots), str(fingerspelled)]) + "\n")
             return "success"
         except PermissionError:
             return "permission error"
         except:
             return "unspecified error"
+
+    def getfilenamefrompath(self, filepath):
+        afterlastslash = filepath.rfind("/") + 1
+        return filepath[afterlastslash:]
 
     def handle_buttonbox_click(self, button):
         standard = self.button_box.standardButton(button)

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -38,6 +38,7 @@ from PyQt5.QtGui import (
 # Ref: https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html
 from gui.initialization_dialog import InitializationDialog
 from gui.corpus_view import CorpusDisplay
+from gui.countxslots_dialog import CountXslotsDialog
 from gui.location_definer import LocationDefinerDialog
 from gui.locationgraphicstest_dialog import LocationGraphicsTestDialog
 from gui.signtypespecification_view import Signtype
@@ -158,6 +159,11 @@ class MainWindow(QMainWindow):
         action_test_location_graphics = QAction('Test location graphics...', parent=self)
         action_test_location_graphics.triggered.connect(self.on_action_test_location_graphics)
         action_test_location_graphics.setCheckable(False)
+
+        # count x-slots
+        action_count_xslots = QAction("Count x-slots...", parent=self)
+        action_count_xslots.triggered.connect(self.on_action_count_xslots)
+        action_count_xslots.setCheckable(False)
 
         # new corpus
         action_new_corpus = QAction(QIcon(self.app_ctx.icons['blank16']), "New corpus", parent=self)
@@ -293,6 +299,9 @@ class MainWindow(QMainWindow):
         menu_location = main_menu.addMenu('&Location')
         menu_location.addAction(action_define_location)
         menu_location.addAction(action_test_location_graphics)
+
+        menu_analysis_beta = main_menu.addMenu("&Analysis functions (beta)")
+        menu_analysis_beta.addAction(action_count_xslots)
 
         corpusname = ""
         if self.corpus and self.corpus.name:
@@ -716,6 +725,10 @@ class MainWindow(QMainWindow):
     def on_action_test_location_graphics(self):
         location_test_window = LocationGraphicsTestDialog(self.app_settings, self.app_ctx, parent=self)
         location_test_window.exec_()
+
+    def on_action_count_xslots(self):
+        count_xslots_window = CountXslotsDialog(self.app_settings, self.app_ctx, parent=self)
+        count_xslots_window.exec_()
 
     def save_new_locations(self, new_locations):
         # TODO: need to reimplement this once corpus class is there


### PR DESCRIPTION
Introduced a very rudimentary x-slot-counting function via a new "Analysis functions (beta)" menu. The GUI is not pretty nor is it terribly robust, but the new function allows the user to count the number of x-slots for each sign in a corpus (or more than one) by specifying:
 - one or more .slpaa files to analyze
 - file format for results (comma- or tab-separated)
 - whether results should be recorded separately per corpus or all combined
 - a filename for the combined results, if applicable