### PR TITLE
Deleting signs 

### DIFF
--- a/src/main/python/gui/corpus_view.py
+++ b/src/main/python/gui/corpus_view.py
@@ -100,16 +100,20 @@ class CorpusDisplay(QWidget):
     def updated_signs(self, signs, current_sign=None):
         self.corpus_model.setsigns(signs)
         self.corpus_model.layoutChanged.emit()
+        
+        # Reset the selection mode
+        try:
+            index = 0 if current_sign is None else list(signs).index(current_sign)
+            # Ref: https://www.qtcentre.org/threads/32007-SetSelection-QListView-Pyqt
+            # # sourcemodelindex = self.corpus_view.model().index(index, 0)
+            # # proxymodelindex = self.corpus_view.model().mapFromSource(sourcemodelindex)
+            # # self.corpus_view.selectionModel().setCurrentIndex(proxymodelindex, QItemSelectionModel.SelectCurrent)
+            self.corpus_view.selectionModel().setCurrentIndex(self.corpus_view.model().index(index, 0), 
+                                                              QItemSelectionModel.SelectCurrent)
 
-        index = 0 if current_sign is None else list(signs).index(current_sign)
-
-        # Ref: https://www.qtcentre.org/threads/32007-SetSelection-QListView-Pyqt
-        # sourcemodelindex = self.corpus_view.model().index(index, 0)
-        # proxymodelindex = self.corpus_view.model().mapFromSource(sourcemodelindex)
-        # self.corpus_view.selectionModel().setCurrentIndex(proxymodelindex, QItemSelectionModel.SelectCurrent)
-        self.corpus_view.selectionModel().setCurrentIndex(self.corpus_view.model().index(index, 0), 
-                                                          QItemSelectionModel.SelectCurrent)
-
+        except ValueError:
+            self.clear()
+             
     def remove_sign(self, sign):
         self.corpus_model.signs.remove(sign)
         self.corpus_model.layoutChanged.emit()

--- a/src/main/python/gui/corpus_view.py
+++ b/src/main/python/gui/corpus_view.py
@@ -104,11 +104,11 @@ class CorpusDisplay(QWidget):
         index = 0 if current_sign is None else list(signs).index(current_sign)
 
         # Ref: https://www.qtcentre.org/threads/32007-SetSelection-QListView-Pyqt
-        sourcemodelindex = self.corpus_view.model().index(index, 0)
-        proxymodelindex = self.corpus_view.model().mapFromSource(sourcemodelindex)
-        self.corpus_view.selectionModel().setCurrentIndex(proxymodelindex, QItemSelectionModel.SelectCurrent)
-        # self.corpus_view.selectionModel().setCurrentIndex(self.corpus_view.model().index(index, 0),
-        #                                                   QItemSelectionModel.SelectCurrent)
+        # sourcemodelindex = self.corpus_view.model().index(index, 0)
+        # proxymodelindex = self.corpus_view.model().mapFromSource(sourcemodelindex)
+        # self.corpus_view.selectionModel().setCurrentIndex(proxymodelindex, QItemSelectionModel.SelectCurrent)
+        self.corpus_view.selectionModel().setCurrentIndex(self.corpus_view.model().index(index, 0), 
+                                                          QItemSelectionModel.SelectCurrent)
 
     def remove_sign(self, sign):
         self.corpus_model.signs.remove(sign)

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -923,14 +923,13 @@ class MainWindow(QMainWindow):
                                         'Do you want to delete the selected sign?')
         if response == QMessageBox.Yes:
             previous = self.corpus.get_previous_sign(self.current_sign.signlevel_information.gloss)
-
+            
             # delete self.current_sign.
             # unintuitive but the argument 'previous' is needed for moving highlight after deleting the sign
             self.signlevel_panel.handle_delete_signlevelinfo(previous)
-            """
-            self.corpus.remove_sign(self.current_sign)
-            self.corpus_display.updated_signs(self.corpus.signs, previous)
-            """
+            # self.corpus.remove_sign(self.current_sign)
+            # self.corpus_display.updated_signs(self.corpus.signs, previous)
+
             self.select_sign([previous])
             self.handle_sign_selected(previous)
             # TODO KV need to also have that sign selected in the corpus view,

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -953,7 +953,10 @@ class MainWindow(QMainWindow):
         selectionmodel = self.corpus_display.corpus_view.selectionModel()
         indices = []
         for sign in signstoselect:
-            indices.append(list(self.corpus.signs).index(sign))
+            try:
+                indices.append(list(self.corpus.signs).index(sign))
+            except ValueError:
+                pass
         # print(indices)
 
     def flag_and_refresh(self, sign=None):

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -907,6 +907,7 @@ class SignLevelMenuPanel(QScrollArea):
             
             # Update corpus display with the previous selection highlighted
             self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
+            self.mainwindow.handle_sign_selected(previous_selection)
 
 
     def handle_signtypebutton_click(self):

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -903,11 +903,16 @@ class SignLevelMenuPanel(QScrollArea):
     def handle_delete_signlevelinfo(self, previous_selection):
         if self.sign:  # does the sign to delete exist?
             self.mainwindow.corpus.remove_sign(self.sign)
-            self.sign_updated.emit(previous_selection)
             
             # Update corpus display with the previous selection highlighted
-            self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
-            self.mainwindow.handle_sign_selected(previous_selection)
+            if previous_selection:
+                self.sign_updated.emit(previous_selection)
+                self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
+                self.mainwindow.handle_sign_selected(previous_selection)
+            
+            else:
+                self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
+                self.mainwindow.handle_sign_selected(previous_selection)
 
 
     def handle_signtypebutton_click(self):

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -905,8 +905,13 @@ class SignLevelMenuPanel(QScrollArea):
             self.mainwindow.corpus.remove_sign(self.sign)
             self.sign_updated.emit(previous_selection)
 
-            # update corpus display with the previous selection highlighted
-            self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
+            if self.sign == previous_selection:
+                # If there is no other sign, update display and highlight nothing anymore
+                self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, None)
+            else:
+                # update corpus display with the previous selection highlighted
+                self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
+
 
     def handle_signtypebutton_click(self):
         signtype_selector = SigntypeSelectorDialog(self.sign.signtype, parent=self)

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -905,11 +905,7 @@ class SignLevelMenuPanel(QScrollArea):
             self.mainwindow.corpus.remove_sign(self.sign)
             self.sign_updated.emit(previous_selection)
             
-            # if self.sign == previous_selection:
-            #     # If there is no other sign, update display and highlight nothing anymore
-            #     self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, [])
-            # :
-            # update corpus display with the previous selection highlighted
+            # Update corpus display with the previous selection highlighted
             self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
 
 

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -341,7 +341,7 @@ class SignSummaryPanel(QScrollArea):
         self.addgridlines()
 
     def entryid_string(self, entryid_int=None):
-        numdigits = self.settings['display']['entryid_digits']
+        numdigits = int(self.settings['display']['entryid_digits'])
         if entryid_int is None:
             entryid_int = self.sign.signlevel_information.entryid
         entryid_string = str(entryid_int)
@@ -904,13 +904,13 @@ class SignLevelMenuPanel(QScrollArea):
         if self.sign:  # does the sign to delete exist?
             self.mainwindow.corpus.remove_sign(self.sign)
             self.sign_updated.emit(previous_selection)
-
-            if self.sign == previous_selection:
-                # If there is no other sign, update display and highlight nothing anymore
-                self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, None)
-            else:
-                # update corpus display with the previous selection highlighted
-                self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
+            
+            # if self.sign == previous_selection:
+            #     # If there is no other sign, update display and highlight nothing anymore
+            #     self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, [])
+            # :
+            # update corpus display with the previous selection highlighted
+            self.mainwindow.corpus_display.updated_signs(self.mainwindow.corpus.signs, previous_selection)
 
 
     def handle_signtypebutton_click(self):

--- a/src/main/python/gui/signlevelinfospecification_view.py
+++ b/src/main/python/gui/signlevelinfospecification_view.py
@@ -132,11 +132,11 @@ class SignLevelInfoPanel(QFrame):
             return self.mainwindow.corpus.highestID+1
 
     def entryid_string(self, entryid_int=None):
-        numdigits = self.settings['display']['entryid_digits']
+        numdigits = int(self.settings['display']['entryid_digits'])
         if entryid_int is None:
             entryid_int = self.entryid()
         entryid_string = str(entryid_int)
-        entryid_string = "0"*(numdigits-len(entryid_string)) + entryid_string
+        entryid_string = "0"*(numdigits - len(entryid_string)) + entryid_string
         return entryid_string
 
     def set_starting_focus(self):

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -516,7 +516,8 @@ class Corpus:
 
         if len(sign_glosses) == 1:
             # If there is only 1 sign, return the same sign
-            previous_gloss = sign_glosses[0]
+            return None
+        
         elif current_index == 0:
             # Otherwise if this is the 1st sign, return the next sign in the list
             previous_gloss = sign_glosses[1]

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -484,14 +484,31 @@ class Corpus:
     def get_sign_glosses(self):
         return sorted([sign.signlevel_information.gloss for sign in self.signs])
 
+
     def get_previous_sign(self, gloss):
+        """Given a sign gloss, return the next gloss to highlight in the list.
+
+        Args:
+            gloss: sign
+
+        Returns:
+            previous_sign: sign
+        """
         sign_glosses = self.get_sign_glosses()
         current_index = sign_glosses.index(gloss)
 
-        # if the very first sign is selected, then return the one after it, otherwise the previous one
-        previous_gloss = sign_glosses[current_index-1] if current_index-1 >= 0 else sign_glosses[1]
+        if len(sign_glosses) == 1:
+            # If there is only 1 sign, return the same sign
+            previous_gloss = sign_glosses[0]
+        elif current_index == 0:
+            # Otherwise if this is the 1st sign, return the next sign in the list
+            previous_gloss = sign_glosses[1]
+        else:
+            # Otherwise, return the previous sign
+            previous_gloss = sign_glosses[current_index - 1]
 
         return self.get_sign_by_gloss(previous_gloss)
+
 
     def get_sign_by_gloss(self, gloss):
         # Every sign has a unique gloss, so this function will always return one sign


### PR DESCRIPTION
Issue #78 - Deleting signs now highlights correctly according to expected behaviour

Case 1: There is more than 1 sign in the list, sign to be deleted is not the first in the corpus
Before deletion:
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/51172655/14842ba1-0127-4788-8aeb-caaf87e81089)
After deletion: (preceding sign is now highlighted)
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/51172655/d9dab61d-90a4-4a1a-9de5-4cbd7db120ef)

Case 2: There is more than 1 sign in the list, sign to be deleted is the first in the corpus
Before deletion:
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/51172655/ddea0f21-bec9-4161-be0d-4b0df4e9f7bc)
After deletion: (following sign is now highlighted)
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/51172655/86c74d2f-f77b-4560-987c-91cb98798ec0)

Case 3: There is only 1 sign left in the corpus that is to be deleted.
Before deletion:
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/51172655/41252312-1d8e-46a5-8ac3-5dc5412a8229)
After deletion: (no signs are left in the corpus)
![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/51172655/ccf9cb3f-d496-46b6-b362-ec8ced32a51b)

