### PR TITLE
add lemma to corpus sort options; fix bug with date-based sorting

### DIFF
--- a/src/main/python/gui/corpus_view.py
+++ b/src/main/python/gui/corpus_view.py
@@ -70,7 +70,7 @@ class CorpusDisplay(QWidget):
         sort_layout.addWidget(sortlabel)
         self.sortcombo = QComboBox()
         self.sortcombo.addItems(
-            ["alpha by gloss (default)", "date created", "date last modified"])
+            ["alpha by gloss (default)", "alpha by lemma", "date created", "date last modified"])
         self.sortcombo.setInsertPolicy(QComboBox.NoInsert)
         self.sortcombo.currentTextChanged.connect(self.sort)
         sort_layout.addWidget(self.sortcombo)

--- a/src/main/python/gui/signlevelinfospecification_view.py
+++ b/src/main/python/gui/signlevelinfospecification_view.py
@@ -59,7 +59,7 @@ class SignLevelInfoPanel(QFrame):
         self.signlevelinfo = signlevelinfo
 
         main_layout = QFormLayout()
-        main_layout.setSpacing(5)  # TODO KV what is this?
+        main_layout.setSpacing(5)
 
         entryid_label = QLabel("Entry ID:")
         gloss_label = QLabel('Gloss:')
@@ -260,9 +260,10 @@ class SignlevelinfoSelectorDialog(QDialog):
             if sli is not None:
                 newsignlevelinfo = SignLevelInformation(signlevel_info=sli)
                 oldsignlevelinfo = self.signlevelinfo_widget.signlevelinfo
+                if newsignlevelinfo != oldsignlevelinfo:
+                    # if anything other than the last modified date has changed, then lastmodified should be set to now
+                    newsignlevelinfo.lastmodifiednow()
                 self.saved_signlevelinfo.emit(newsignlevelinfo)
-                if self.mainwindow.current_sign is not None and newsignlevelinfo != oldsignlevelinfo:
-                    self.mainwindow.current_sign.lastmodifiednow()
                 self.accept()
 
         elif standard == QDialogButtonBox.RestoreDefaults:


### PR DESCRIPTION
There was an order-of-operations error in how the lastmodified date was being updated when a sign was updated. Also, the default implementation of `QSortFilterProxyModel.sort()` isn't able to compare `datetime.datetime` objects, so I deal with those explicitly and then pass the rest off.