### PR TITLE
Lock the upper part on the module specification panel

### DIFF
--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -90,11 +90,11 @@ class ModuleSelectorDialog(QDialog):
         self.arts_and_addedinfo_layout.setAlignment(self.addedinfobutton, Qt.AlignTop)
 
         main_layout.addLayout(self.arts_and_addedinfo_layout)
-
+        self.arts_and_addedinfo_layout.minimumSize()
         self.xslot_widget = XslotLinkingPanel(xslotstructure=xslotstructure,
                                               timingintervals=timingintervals,
                                               parent=self)
-        self.xslot_widget.setFixedHeight(300)
+        self.xslot_widget.setFixedHeight(250)
 
         if self.mainwindow.app_settings['signdefaults']['xslot_generation'] != 'none':
             main_layout.addWidget(self.xslot_widget)
@@ -532,7 +532,7 @@ class XslotLinkingPanel(QFrame):
         main_layout = QVBoxLayout()
 
         self.link_intro_label = QLabel("Click on the relevant point(s) or interval(s) to link this module.")
-        self.link_intro_label.setFixedHeight(30)
+        self.link_intro_label.setFixedHeight(16)
         main_layout.addWidget(self.link_intro_label)
 
         self.xslotlinkscene = XslotLinkScene(timingintervals=self.timingintervals, parentwidget=self)

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -78,6 +78,8 @@ class ModuleSelectorDialog(QDialog):
                                                              incl_articulator_subopts=incl_articulator_subopts,
                                                              inphase=inphase,
                                                              parent=self)
+        self.articulators_widget.setFixedHeight(100)
+
         if self.includearticulatorselection:
             self.arts_and_addedinfo_layout.addWidget(self.articulators_widget)
 
@@ -92,6 +94,8 @@ class ModuleSelectorDialog(QDialog):
         self.xslot_widget = XslotLinkingPanel(xslotstructure=xslotstructure,
                                               timingintervals=timingintervals,
                                               parent=self)
+        self.xslot_widget.setFixedHeight(300)
+
         if self.mainwindow.app_settings['signdefaults']['xslot_generation'] != 'none':
             main_layout.addWidget(self.xslot_widget)
 
@@ -528,6 +532,7 @@ class XslotLinkingPanel(QFrame):
         main_layout = QVBoxLayout()
 
         self.link_intro_label = QLabel("Click on the relevant point(s) or interval(s) to link this module.")
+        self.link_intro_label.setFixedHeight(30)
         main_layout.addWidget(self.link_intro_label)
 
         self.xslotlinkscene = XslotLinkScene(timingintervals=self.timingintervals, parentwidget=self)


### PR DESCRIPTION
The current module specification panel expands proportionally, creating unused space at the upper part of the window (cf. issue #254). This PR deals with this issue by locking the 'articulators' and 'xslot' sections and allows space for content-rich areas.

See the comparison below:

| Branch 'main' | Branch '#254' |
| --------------- | --------------- |
| ![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/43150234/7913cbfb-47d1-4f75-a11c-60f4b14d8a99) | ![image](https://github.com/PhonologicalCorpusTools/SLPAA/assets/43150234/a54970e2-48e7-435c-88d4-966674d0cc87) |



**Details:**
On Win11, the upper part now constantly occupies 340 pixels and does not expand. (100px for articulators buttons + module notes and 240px for xslot widget) 
 - self.arts_and_addedinfo_layout.sizeHint(): PyQt5.QtCore.QSize(477, 100)
 - self.xslot_widget.sizeHint(): PyQt5.QtCore.QSize(1301, 240)

On macOS Sonoma, the upper part takes 360px (112 + 248).
 - self.arts_and_addedinfo_layout.sizeHint(): PyQt5.QtCore.QSize(626, 112)
 - self.xslot_widget.sizeHint(): PyQt5.QtCore.QSize(1158, 248)



**More details:**
I used the `setFixedHeight` method to specify number of pixels for `self.articulators_widget` ("This module applies to..."), `self.link_intro_label` ("Click on the relevant point(s)...") and self.xslot_widget.

My resolution settings are:
 - Win11: 1920x1080
 - macOS Sonoma: 1512x982