### PR TITLE
250 bug slpaa and ubuntu device crashes on toolbar selection

### DIFF
--- a/src/main/python/gui/location_definer.py
+++ b/src/main/python/gui/location_definer.py
@@ -472,10 +472,10 @@ class LocationDefinerTabWidget(QTabWidget):
         self.addTab(QWidget(), QIcon(self.app_ctx.icons['plus']), 'Add location')
 
         # hide close button for the '' tab. The location of the close button is OS-dependent.
-        if os.name == 'nt':  # For Windows, buttons appear on the right
-            self.tabbar.tabButton(self.tabbar.count()-1, QTabBar.RightSide).hide()
-        elif os.name == 'posix':  # For Linux and macOS, they are on the left
-            self.tabbar.tabButton(self.tabbar.count()-1, QTabBar.LeftSide).hide()
+        #if os.name == 'nt':  # For Windows, buttons appear on the right
+        #    self.tabbar.tabButton(self.tabbar.count()-1, QTabBar.RightSide).hide()
+        #elif os.name == 'posix':  # For Linux and macOS, they are on the left
+        #    self.tabbar.tabButton(self.tabbar.count()-1, QTabBar.LeftSide).hide()
 
     def add_location_tab(self, index):
         self.number_pages += 1
@@ -525,11 +525,13 @@ class LocationDefinerTabWidget(QTabWidget):
     def close_handler(self, index):
         widget = self.widget(index)
 
-        if widget:
+        if isinstance(widget, LocationDefinerPage):   # clicked Ⓧ on a location tab
             if not widget.default and widget.image_path:
                 os.remove(widget.image_path)
 
             widget.deleteLater()
+        else:                                         # Ⓧ on the 'Add Location' tab
+            return
 
         self.removeTab(index)
 

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -625,9 +625,10 @@ class MainWindow(QMainWindow):
         self.app_settings['display']['sub_visualsummary_size'] = self.app_qsettings.value('sub_visualsummary_size',
                                                                                           defaultValue=QSize(1200, 900))
 
-        self.app_settings['display']['sig_figs'] = self.app_qsettings.value('sig_figs', defaultValue=2)
+        self.app_settings['display']['sig_figs'] = self.app_qsettings.value('sig_figs', defaultValue=2, type=int)
         self.app_settings['display']['tooltips'] = bool(self.app_qsettings.value('tooltips', defaultValue=True))
-        self.app_settings['display']['entryid_digits'] = self.app_qsettings.value('entryid_digits', defaultValue=4)
+        self.app_settings['display']['entryid_digits'] = self.app_qsettings.value('entryid_digits', defaultValue=4,
+                                                                                  type=int)
         self.app_qsettings.endGroup()
 
         self.app_qsettings.beginGroup('metadata')


### PR DESCRIPTION
Although clicking on the tool bar does not crash the program on my end, I did find that two options triggered errors independently: 1. Settings > Preferences... and 2. Location > Define locations... This PR addresses both.

@brdiep113 Brian could you kindly check if the issues have been resolved and if the program no longer crashes?

## 1. Settings > Preferences... 
This is from a known issue where the two settings parameters `entryid_digits` and `sig_figs` are incorrectly typed as str instead of int on Ubuntu.

So the solution was simple: explicitly type `sig_figs` and `entryid_digits` as int from the very beginning.

## 2. Location > Define locations...
The location definer dialog has tabs that can be closed by clicking Ⓧ, which appear on the left or right side of the tab. The right-most tab is 'Add new tab' and we don't want the Ⓧ button for this tab. So we previously deleted the button. However, since Ⓧ appears on different location by OS (e.g., right-hand side on Win, and left side on macOS), I previously wrote a conditional that locates and deletes this Ⓧ differently depending on the OS (87c9bd800bf60d79df3c0df78f432a0d15b81241). There, I grouped Linux (including Ubuntu) with macOS to expect Ⓧ on the left side of a tab, but the problem was that the Ⓧ location is not fixed on Linux. 

This PR takes a different approach. Rather than deleting Ⓧ from 'Add new tab', the program now ignores the input when the user clicks (x) on the 'New Location' tab.