### PR TITLE
to address issue #259

### DIFF
--- a/src/main/python/gui/locationspecification_view.py
+++ b/src/main/python/gui/locationspecification_view.py
@@ -447,7 +447,7 @@ class LocationSpecificationPanel(ModuleSpecificationPanel):
 
         main_layout = QVBoxLayout()
 
-        # This widget has three separate location trees, so that we can flip back and forth between
+        # This widget has two separate location trees, so that we can flip back and forth between
         # location types without losing intermediate information. However, once the save button is
         # clicked only the tree for the current location type is saved with the module.
         self.treemodel_body = None
@@ -620,6 +620,9 @@ class LocationSpecificationPanel(ModuleSpecificationPanel):
             self.listmodel_body = lm
         elif self.getcurrentlocationtype().purelyspatial:
             self.listmodel_spatial = lm
+
+        # ensure the first item in the selected locations list (if any) is selected/highlighted
+        self.locationoptionsselectionpanel.pathslistview.setindex(-1)
 
     def check_phonologicalloc_cb(self, checked):
         self.phonological_cb.setChecked(True)

--- a/src/main/python/gui/modulespecification_widgets.py
+++ b/src/main/python/gui/modulespecification_widgets.py
@@ -332,6 +332,19 @@ class TreeListView(QListView):
     def __init__(self):
         super().__init__()
 
+    # sets the currently selected index to be indexint
+    # if indexint is -1:
+    #   if there's at least one item in the list then the first one is selected
+    #   if there's no content in the list then nothing happens
+    def setindex(self, indexint):
+        if indexint == -1:
+            if self.model().rowCount() > 0:
+                indexint = 0
+            else:
+                return
+        indexobj = self.model().index(indexint, 0)
+        self.setCurrentIndex(indexobj)
+
     def keyPressEvent(self, event):
         key = event.key()
         # modifiers = event.modifiers()


### PR DESCRIPTION
when user opens an existing location module, highlight/select the first location option in the selected list (if any) and display its surfaces/subareas