### PR TITLE
fix issue #261

### DIFF
--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -471,6 +471,7 @@ class SignSummaryPanel(QScrollArea):
         if mods_count > 0:
             if self.mainwindow.app_settings['signdefaults']['xslot_generation'] == 'none':
                 # everything just gets listed vertically
+
                 for mod in modules:
                     m_id = mod.uniqueid
                     self.current_y += self.default_xslot_height + self.verticalspacing
@@ -520,10 +521,10 @@ class SignSummaryPanel(QScrollArea):
         if mods_count > 0:
             if self.mainwindow.app_settings['signdefaults']['xslot_generation'] == 'none':
                 # everything just gets listed vertically
-                self.current_y += self.default_xslot_height + self.verticalspacing
 
                 for mod in modules:
                     m_id = mod.uniqueid
+                    self.current_y += self.default_xslot_height + self.verticalspacing
                     if isrel:
                         if mod.usesarticulator(HAND, artnum):
                             articulator = HAND
@@ -543,7 +544,6 @@ class SignSummaryPanel(QScrollArea):
                         paramrect.setToolTip(paramabbrev)
                         paramrect.setRect(*self.getxywh(None))  # how big is it / where does it go?
                         self.moduleitems.append(paramrect)
-                        # self.current_y += 1
                         self.scene.addItem(paramrect)
             else:  # 'manual' or 'auto'
                 # associate modules with x-slots


### PR DESCRIPTION
Relevant for when x-slots are turned off: ensure that the y-coordinate gets increased each time a new module's rectangle is added to the visual summary, so that they don't get stacked on top of one another.

It was just a question of moving the increment from outside a per-module loop, to inside the loop.