### PR TITLE
fix issue #263

### DIFF
--- a/src/main/python/gui/corpus_view.py
+++ b/src/main/python/gui/corpus_view.py
@@ -89,21 +89,11 @@ class CorpusDisplay(QWidget):
         main_layout.addLayout(sort_layout)
 
     def handle_selection(self, index):
-        # gloss = self.corpus_model.glosses[index.row()]
-        # themodel = index.model()
-        # if hasattr(themodel, 'mapToSource'):
-        #     print("selected index is from a proxy model!")
-        #     underlyingindex = themodel.mapToSource(index)
-        #     underlyingsign = self.corpus_model.signs[underlyingindex.row()]
-        #     print("row: ", underlyingindex.row(), " / sign gloss: ", underlyingsign.signlevel_information.gloss)
-        # else:
-        #     print("selected index is no from from a uproxy model!")
-
-        index = index.model().mapToSource(index)
-        sign = self.corpus_model.itemFromIndex(index).sign  #  signs[index.row()]  #.signlevel_information.gloss
-        # print("row: ", index.row(), " / sign gloss: ", sign.signlevel_information.gloss)
-        # self.selected_gloss.emit(gloss)
-        self.selected_sign.emit(sign)
+        themodel = index.model()
+        if themodel is not None:
+            index = themodel.mapToSource(index)
+            sign = self.corpus_model.itemFromIndex(index).sign  
+            self.selected_sign.emit(sign)
 
     def updated_signs(self, signs, current_sign=None):
         self.corpus_model.setsigns(signs)

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -27,7 +27,8 @@ from PyQt5.QtWidgets import (
     QUndoStack,
     QMdiArea,
     QMdiSubWindow,
-    QWidget
+    QWidget,
+    QDialog
 )
 
 from PyQt5.QtGui import (
@@ -924,13 +925,20 @@ class MainWindow(QMainWindow):
         self.close()
 
     def on_action_new_sign(self, clicked):
+        # save currently-selected sign in case user cancels creating the new sign
+        stashed_corpusselection = self.corpus_display.corpus_view.currentIndex()
+
         self.current_sign = None
-        # self.new_sign = None
         self.action_delete_sign.setEnabled(False)
 
         self.corpus_display.corpus_view.clearSelection()
         self.signlevel_panel.clear()
-        self.signlevel_panel.handle_signlevelbutton_click()
+        dialogresult = self.signlevel_panel.handle_signlevelbutton_click()
+
+        # reset to previously-select sign if user cancels out of creating the new sign
+        if dialogresult == QDialog.Rejected:
+            self.corpus_display.corpus_view.setCurrentIndex(stashed_corpusselection)
+            self.corpus_display.handle_selection(stashed_corpusselection)
 
     def on_action_delete_sign(self, clicked):
         response = QMessageBox.question(self, 'Delete the selected sign',

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -878,7 +878,8 @@ class SignLevelMenuPanel(QScrollArea):
     def handle_signlevelbutton_click(self):
         signlevelinfo_selector = SignlevelinfoSelectorDialog(self.sign.signlevel_information if self.sign else None, parent=self)
         signlevelinfo_selector.saved_signlevelinfo.connect(self.handle_save_signlevelinfo)
-        signlevelinfo_selector.exec_()
+        dialogresult = signlevelinfo_selector.exec_()
+        return dialogresult
 
     def handle_save_signlevelinfo(self, signlevelinfo):
         if self.sign:


### PR DESCRIPTION
Ensure that if the user cancels out of creating a new sign, the software returns to focus on the previously-selected sign (including none if that's the case).