### PR TITLE
283 add entryid flexibility/functionality

### DIFF
--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -13,7 +13,8 @@ from PyQt5.QtCore import (
     QSize,
     QSettings,
     QPoint,
-    pyqtSignal
+    pyqtSignal,
+    QCoreApplication
 )
 
 from PyQt5.QtWidgets import (
@@ -72,6 +73,8 @@ class MainWindow(QMainWindow):
     def __init__(self, app_ctx):
         super().__init__()
         self.app_ctx = app_ctx
+        QCoreApplication.setOrganizationName("UBC Phonology Tools")
+        QCoreApplication.setApplicationName("Sign Language Phonetic Annotator and Analyzer")
 
         self.corpus = None
         self.current_sign = None
@@ -582,70 +585,76 @@ class MainWindow(QMainWindow):
     def handle_app_settings(self):
         self.app_settings = defaultdict(dict)
 
-        self.app_qsettings = QSettings('UBC Phonology Tools',
-                                       application='Sign Language Phonetic Annotator and Analyzer')
+        self.app_qsettings = QSettings()  # organization name & application name were set in MainWindow.__init__()
 
         self.app_qsettings.beginGroup('storage')
         self.app_settings['storage']['recent_folder'] = self.app_qsettings.value(
             'recent_folder',
             defaultValue=os.path.expanduser('~/Documents'))
-        self.app_settings['storage']['corpora'] = self.app_qsettings.value('corpora',
-                                                                           defaultValue=os.path.normpath(
-                                                                               os.path.join(
-                                                                                   os.path.expanduser('~/Documents'),
-                                                                                   'PCT', 'SLP-AA', 'CORPORA')))
-        self.app_settings['storage']['image'] = self.app_qsettings.value('image',
-                                                                         defaultValue=os.path.normpath(
-                                                                             os.path.join(
-                                                                                 os.path.expanduser('~/Documents'),
-                                                                                 'PCT', 'SLP-AA', 'IMAGE')))
-        self.app_qsettings.endGroup()
+        self.app_settings['storage']['corpora'] = self.app_qsettings.value(
+            'corpora',
+            defaultValue=os.path.normpath(os.path.join(os.path.expanduser('~/Documents'), 'PCT', 'SLP-AA', 'CORPORA'))
+        )
+        self.app_settings['storage']['image'] = self.app_qsettings.value(
+            'image',
+            defaultValue=os.path.normpath(os.path.join(os.path.expanduser('~/Documents'), 'PCT', 'SLP-AA', 'IMAGE'))
+        )
+        self.app_qsettings.endGroup()  # storage
 
         self.app_qsettings.beginGroup('display')
         self.app_settings['display']['size'] = self.app_qsettings.value('size', defaultValue=QSize(2000, 1200))
         self.app_settings['display']['position'] = self.app_qsettings.value('position', defaultValue=QPoint(0, 23))
 
-        self.app_settings['display']['sub_corpus_show'] = bool(self.app_qsettings.value('sub_corpus_show',
-                                                                                        defaultValue=True))
-        self.app_settings['display']['sub_corpus_pos'] = self.app_qsettings.value('sub_corpus_pos',
-                                                                                  defaultValue=QPoint(0, 0))
-        self.app_settings['display']['sub_corpus_size'] = self.app_qsettings.value('sub_corpus_size',
-                                                                                   defaultValue=QSize(340, 700))
+        self.app_settings['display']['sub_corpus_show'] = bool(self.app_qsettings.value('sub_corpus_show', defaultValue=True))
+        self.app_settings['display']['sub_corpus_pos'] = self.app_qsettings.value('sub_corpus_pos', defaultValue=QPoint(0, 0))
+        self.app_settings['display']['sub_corpus_size'] = self.app_qsettings.value('sub_corpus_size', defaultValue=QSize(340, 700))
 
-        self.app_settings['display']['sub_signlevelmenu_show'] = bool(self.app_qsettings.value('sub_signlevelmenu_show',
-                                                                                               defaultValue=True))
-        self.app_settings['display']['sub_signlevelmenu_pos'] = self.app_qsettings.value('sub_signlevelmenu_pos',
-                                                                                         defaultValue=QPoint(340, 0))
-        self.app_settings['display']['sub_signlevelmenu_size'] = self.app_qsettings.value('sub_signlevelmenu_size',
-                                                                                          defaultValue=QSize(320, 700))
+        self.app_settings['display']['sub_signlevelmenu_show'] = bool(self.app_qsettings.value('sub_signlevelmenu_show', defaultValue=True))
+        self.app_settings['display']['sub_signlevelmenu_pos'] = self.app_qsettings.value('sub_signlevelmenu_pos', defaultValue=QPoint(340, 0))
+        self.app_settings['display']['sub_signlevelmenu_size'] = self.app_qsettings.value('sub_signlevelmenu_size', defaultValue=QSize(320, 700))
 
-        self.app_settings['display']['sub_visualsummary_show'] = bool(self.app_qsettings.value('sub_visualsummary_show',
-                                                                                               defaultValue=True))
-        self.app_settings['display']['sub_visualsummary_pos'] = self.app_qsettings.value('sub_visualsummary_pos',
-                                                                                         defaultValue=QPoint(660, 0))
-        self.app_settings['display']['sub_visualsummary_size'] = self.app_qsettings.value('sub_visualsummary_size',
-                                                                                          defaultValue=QSize(1200, 900))
+        self.app_settings['display']['sub_visualsummary_show'] = bool(self.app_qsettings.value('sub_visualsummary_show', defaultValue=True))
+        self.app_settings['display']['sub_visualsummary_pos'] = self.app_qsettings.value('sub_visualsummary_pos', defaultValue=QPoint(660, 0))
+        self.app_settings['display']['sub_visualsummary_size'] = self.app_qsettings.value('sub_visualsummary_size', defaultValue=QSize(1200, 900))
 
         self.app_settings['display']['sig_figs'] = self.app_qsettings.value('sig_figs', defaultValue=2, type=int)
         self.app_settings['display']['tooltips'] = bool(self.app_qsettings.value('tooltips', defaultValue=True))
-        self.app_settings['display']['entryid_digits'] = self.app_qsettings.value('entryid_digits', defaultValue=4,
-                                                                                  type=int)
-        self.app_qsettings.endGroup()
+        # backward compatibility:
+        #   entryid_digits used to be under the display section but has now (20240229) moved to a separate entryid section
+        #   if this setting was saved under display, make sure it's re-stored in entryid and that 'display/entryid_digits' is removed
+        existing_entryid_digits = None
+        if self.app_qsettings.contains('entryid_digits'):
+            existing_entryid_digits = self.app_qsettings.value('entryid_digits')
+            self.app_qsettings.remove('entryid_digits')
+        self.app_qsettings.endGroup()  # display
+
+        self.app_qsettings.beginGroup('entryid')
+        self.app_qsettings.beginGroup('counter')
+        self.app_qsettings.setValue('visible', bool(self.app_qsettings.value('visible', defaultValue=False, type=bool)))
+        self.app_qsettings.setValue('order', int(self.app_qsettings.value('order', defaultValue=0, type=int)))
+        counterdigits = existing_entryid_digits or int(self.app_qsettings.value('digits', defaultValue=4, type=int))
+        self.app_qsettings.setValue('digits', counterdigits)
+        self.app_qsettings.endGroup()  # counter
+        self.app_qsettings.beginGroup('date')
+        self.app_qsettings.setValue('visible', bool(self.app_qsettings.value('visible', defaultValue=False, type=bool)))
+        self.app_qsettings.setValue('order', int(self.app_qsettings.value('order', defaultValue=0, type=int)))
+        self.app_qsettings.setValue('format', str(self.app_qsettings.value('format', defaultValue='YYYY-MM', type=str)))
+        self.app_qsettings.endGroup()  # date
+        self.app_qsettings.setValue('delimiter', self.app_qsettings.value('delimiter', defaultValue='_', type=str))
+        self.app_qsettings.endGroup()  # entryid
 
         self.app_qsettings.beginGroup('metadata')
         self.app_settings['metadata']['coder'] = self.app_qsettings.value('coder', defaultValue='NEWUSERNAME')
-        self.app_qsettings.endGroup()
+        self.app_qsettings.endGroup()  # metadata
 
         self.app_qsettings.beginGroup('reminder')
         self.app_settings['reminder']['overwrite'] = bool(self.app_qsettings.value('overwrite', defaultValue=True))
-        self.app_qsettings.endGroup()
+        self.app_qsettings.endGroup()  # reminder
 
         self.app_qsettings.beginGroup('signdefaults')
-        self.app_settings['signdefaults']['handdominance'] = self.app_qsettings.value('handdominance',
-                                                                                      defaultValue='R')
+        self.app_settings['signdefaults']['handdominance'] = self.app_qsettings.value('handdominance', defaultValue='R')
         self.app_settings['signdefaults']['signtype'] = self.app_qsettings.value('signtype', defaultValue='none')
-        self.app_settings['signdefaults']['xslot_generation'] = self.app_qsettings.value('xslot_generation',
-                                                                                         defaultValue='none')
+        self.app_settings['signdefaults']['xslot_generation'] = self.app_qsettings.value('xslot_generation', defaultValue='none')
         self.app_qsettings.beginGroup('partial_xslots')
         self.app_settings['signdefaults']['partial_xslots'] = defaultdict(dict)
         self.app_settings['signdefaults']['partial_xslots'][str(Fraction(1, 2))] = \
@@ -669,8 +678,7 @@ class MainWindow(QMainWindow):
             os.makedirs(self.app_settings['storage']['image'])
 
     def save_app_settings(self):
-        self.app_qsettings = QSettings('UBC Phonology Tools',
-                                       application='Sign Language Phonetic Annotator and Analyzer')
+        self.app_qsettings = QSettings()  # organization name & application name were set in MainWindow.__init__()
 
         self.app_qsettings.beginGroup('storage')
         self.app_qsettings.setValue('recent_folder', self.app_settings['storage']['recent_folder'])
@@ -687,8 +695,10 @@ class MainWindow(QMainWindow):
 
         self.app_qsettings.setValue('sig_figs', self.app_settings['display']['sig_figs'])
         self.app_qsettings.setValue('tooltips', self.app_settings['display']['tooltips'])
-        self.app_qsettings.setValue('entryid_digits', self.app_settings['display']['entryid_digits'])
         self.app_qsettings.endGroup()
+
+        # We don't need to explicitly save any of the 'entryid' group values, because they are never cached
+        # into self.app_settings; they're always directly saved to and referenced from QSettings in real time
 
         self.app_qsettings.beginGroup('metadata')
         self.app_qsettings.setValue('coder', self.app_settings['metadata']['coder'])
@@ -810,30 +820,6 @@ class MainWindow(QMainWindow):
 
     @check_unsaved_corpus
     def on_action_save(self, clicked):
-        # signlevel_info = self.signlevelinfo_scroll.get_value()
-        # location_transcription_info = self.parameter_scroll.location_layout.get_location_value()
-        # global_hand_info = self.transcription_scroll.global_info.get_value()
-        # configs = [self.transcription_scroll.config1.get_value(),
-        #            self.transcription_scroll.config2.get_value()]
-        #
-        # # if missing then some of them will be none
-        # if signlevel_info and location_transcription_info and global_hand_info and configs:
-        #     if self.current_sign:
-        #         response = QMessageBox.question(self, 'Overwrite the current sign',
-        #                                         'Do you want to overwrite the existing transcriptions?')
-        #         if response == QMessageBox.Yes:
-        #             self.corpus.remove_sign(self.current_sign)
-        #         else:
-        #             return
-        #
-        #     if not self.new_sign:
-        #         self.new_sign = Sign(signlevel_info, global_hand_info, configs, location_transcription_info)
-        #     # new_sign = self.new_sign if self.new_sign else Sign(signlevel_info, global_hand_info, configs, location_transcription_info)
-        #     self.corpus.add_sign(self.new_sign)
-        #     self.corpus_view.updated_glosses(self.corpus.get_sign_glosses(), self.new_sign.signlevel_information.gloss)
-        #     self.current_sign = self.new_sign
-        #     self.action_delete_sign.setEnabled(True)
-
         if self.corpus.path:
             self.corpus.name = self.corpus_display.corpus_title.text()
             self.save_corpus_binary()
@@ -911,7 +897,7 @@ class MainWindow(QMainWindow):
         self.corpus_display.updated_signs(self.corpus.signs)
         if len(self.corpus.signs) > 0:
             self.corpus_display.selected_sign.emit((list(self.corpus.signs))[0])
-        else: # if loading a blank corpus
+        else:  # if loading a blank corpus
             self.signsummary_panel.mainwindow.current_sign = None # refreshsign() checks for this
             self.signsummary_panel.refreshsign(None)
             self.signlevel_panel.clear()
@@ -919,7 +905,7 @@ class MainWindow(QMainWindow):
 
         self.unsaved_changes = False
 
-        return self.corpus is not None  # bool(Corpus)
+        return self.corpus is not None
 
     def on_action_close(self, clicked):
         self.close()
@@ -966,7 +952,6 @@ class MainWindow(QMainWindow):
                 indices.append(list(self.corpus.signs).index(sign))
             except ValueError:
                 pass
-        # print(indices)
 
     def flag_and_refresh(self, sign=None):
         # this function is called when sign_updated Signal is emitted, i.e., any sign changes

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -630,7 +630,7 @@ class MainWindow(QMainWindow):
 
         self.app_qsettings.beginGroup('entryid')
         self.app_qsettings.beginGroup('counter')
-        self.app_qsettings.setValue('visible', bool(self.app_qsettings.value('visible', defaultValue=False, type=bool)))
+        self.app_qsettings.setValue('visible', bool(self.app_qsettings.value('visible', defaultValue=True, type=bool)))
         self.app_qsettings.setValue('order', int(self.app_qsettings.value('order', defaultValue=0, type=int)))
         counterdigits = existing_entryid_digits or int(self.app_qsettings.value('digits', defaultValue=4, type=int))
         self.app_qsettings.setValue('digits', counterdigits)

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -6,6 +6,7 @@ from PyQt5.QtCore import (
     QRectF,
     QPoint,
     pyqtSignal,
+    QSettings
 )
 
 from PyQt5.QtWidgets import (
@@ -325,7 +326,7 @@ class SignSummaryPanel(QScrollArea):
         signleveltext = QGraphicsTextItem()
         signleveltext.setPlainText("Welcome! Add a new sign to get started.")
         if self.sign is not None:
-            signleveltext.setPlainText(self.sign.signlevel_information.gloss + " - " + self.entryid_string())
+            signleveltext.setPlainText(self.sign.signlevel_information.gloss + " - " + self.sign.signlevel_information.entryid.display_string())
         signleveltext.setPos(self.x_offset, self.current_y)
         self.current_y += 30
         self.scene.addItem(signleveltext)
@@ -339,14 +340,6 @@ class SignSummaryPanel(QScrollArea):
         self.addhand(2)
         self.addnonhand()
         self.addgridlines()
-
-    def entryid_string(self, entryid_int=None):
-        numdigits = int(self.settings['display']['entryid_digits'])
-        if entryid_int is None:
-            entryid_int = self.sign.signlevel_information.entryid
-        entryid_string = str(entryid_int)
-        entryid_string = "0" * (numdigits - len(entryid_string)) + entryid_string
-        return entryid_string
 
     def addsigntype(self):
         if self.sign.signtype is not None:

--- a/src/main/python/gui/preference_dialog.py
+++ b/src/main/python/gui/preference_dialog.py
@@ -1,8 +1,11 @@
+from datetime import datetime
+
 from PyQt5.QtWidgets import (
     QDialog,
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
+    QLayout,
     QFormLayout,
     QTabWidget,
     QSpinBox,
@@ -13,10 +16,11 @@ from PyQt5.QtWidgets import (
     QRadioButton,
     QButtonGroup,
     QMessageBox,
-    QPushButton
+    QPushButton,
+    QComboBox
 )
 
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, QSettings
 
 from constant import FRACTION_CHAR
 from fractions import Fraction
@@ -45,16 +49,235 @@ class DisplayTab(QWidget):
         self.show_tooltip.setChecked(settings['display']['tooltips'])
         main_layout.addRow(QLabel("Show tooltip:"), self.show_tooltip)
 
-        self.entryid_digits = QSpinBox(parent=self)
-        self.entryid_digits.setMinimum(1)
-        self.entryid_digits.setValue(settings['display']['entryid_digits'])
-        main_layout.addRow(QLabel("Number of displayed entry ID digits:"), self.entryid_digits)
-
     def save_settings(self):
         self.settings['display']['sig_figs'] = int(self.decimal_place.value())
         self.settings['display']['tooltips'] = self.show_tooltip.isChecked()
         self.settings['metadata']['coder'] = str(self.coder_name.text())
-        self.settings['display']['entryid_digits'] = self.entryid_digits.value()
+
+
+class EntryIDElementComboBox(QComboBox):
+    delim_descriptions = {
+        "_": "underscore",
+        "-": "hyphen",
+        ".": "period",
+        "": "none"
+    }
+
+    def __init__(self, datatype, curvalue=None, **kwargs):
+        super().__init__(**kwargs)
+        self.setInsertPolicy(QComboBox.NoInsert)
+        self.datatype = datatype
+
+        if self.datatype == "dateformat":
+            self.addItems(["YYYY-MM-DD", "YYYYMMDD", "YYYY-MM", "YYYYMM", "YYYY"])
+        elif self.datatype == "delimiter":
+            self.addItems([k + " (" + v + ")" for (k, v) in self.delim_descriptions.items()])
+
+        self.set_value(curvalue)
+
+    def set_value(self, curvalue):
+        if curvalue is not None:
+            if self.datatype == "dateformat":
+                curtext = curvalue.replace("%Y", "YYYY").replace("%m", "MM").replace("%d", "DD")
+            elif self.datatype == "delimiter":
+                curtext = curvalue + " (" + self.delim_descriptions[curvalue] + ")"
+            self.setCurrentText(curtext)
+
+    def get_value(self):
+        if self.datatype == "dateformat":
+            return self.currentText().replace("YYYY", "%Y").replace("MM", "%m").replace("DD", "%d")
+        elif self.datatype == "delimiter":
+            return self.currentText()[0].replace("(", "")
+
+
+# This tab facilitates user interaction with EntryID-related settings in the preference dialog.
+class EntryIDTab(QWidget):
+    def __init__(self, settings, **kwargs):
+        super().__init__(**kwargs)
+
+        main_layout = QVBoxLayout()
+        self.setLayout(main_layout)
+
+        self.instructions_label = QLabel("Select which elements, and in which order, will comprise the Entry ID for each sign.")
+        main_layout.addWidget(self.instructions_label)
+        self.qsettings_entryid = QSettings()  # organization name & application name were set in MainWindow.__init__()
+        self.qsettings_entryid.beginGroup('entryid')
+
+        form_layout = QFormLayout()
+
+        self.counter_label = QLabel("Sequential number of sign in corpus")
+        self.counter_layout = QHBoxLayout()
+        self.counter_cb = QCheckBox(parent=self)
+        self.counter_cb.setChecked(bool(self.qsettings_entryid.value('counter/visible')))
+        self.counter_layout.addWidget(self.counter_cb)
+        self.counter_order = QSpinBox(parent=self)
+        self.counter_order.setMinimum(0)
+        self.counter_order.setValue(int(self.qsettings_entryid.value('counter/order')))
+        self.counter_layout.addWidget(self.counter_order)
+        self.counter_layout.addStretch()
+        self.counterdigits_label = QLabel("Min # of displayed digits:")
+        self.counter_layout.addWidget(self.counterdigits_label)
+        self.counterdigits_spin = QSpinBox(parent=self)
+        self.counterdigits_spin.setMinimum(1)
+        self.counterdigits_spin.setValue(int(self.qsettings_entryid.value('counter/digits')))
+        self.counter_layout.addWidget(self.counterdigits_spin)
+        self.addupdatelisteners(self.counter_layout)
+        form_layout.addRow(self.counter_label, self.counter_layout)
+
+        self.date_label = QLabel("Date sign created")
+        self.date_layout = QHBoxLayout()
+        self.date_cb = QCheckBox(parent=self)
+        self.date_cb.setChecked(bool(self.qsettings_entryid.value('date/visible')))
+        self.date_layout.addWidget(self.date_cb)
+        self.date_order = QSpinBox(parent=self)
+        self.date_order.setMinimum(0)
+        self.date_order.setValue(int(self.qsettings_entryid.value('date/order')))
+        self.date_layout.addWidget(self.date_order)
+        self.date_layout.addStretch()
+        self.dateformat_label = QLabel("Format:")
+        self.date_layout.addWidget(self.dateformat_label)
+        tempformatvalue = str(self.qsettings_entryid.value('date/format'))
+        self.dateformat_combo = EntryIDElementComboBox(datatype="dateformat", curvalue=str(self.qsettings_entryid.value('date/format')), parent=self)
+        self.date_layout.addWidget(self.dateformat_combo)
+        self.addupdatelisteners(self.date_layout)
+        form_layout.addRow(self.date_label, self.date_layout)
+
+        self.coder_label = QLabel("Coder metadata (not yet active)")
+        self.coder_layout = QHBoxLayout()
+        self.coder_cb = QCheckBox(parent=self)
+        self.coder_layout.addWidget(self.coder_cb)
+        self.coder_order = QSpinBox(parent=self)
+        self.coder_order.setMinimum(0)
+        self.coder_layout.addWidget(self.coder_order)
+        self.coder_layout.addStretch()
+        self.addupdatelisteners(self.coder_layout)
+        form_layout.addRow(self.coder_label, self.coder_layout)
+        # TODO implement details; see https://github.com/PhonologicalCorpusTools/SLPAA/issues/18
+
+        self.signer_label = QLabel("Signer metadata (not yet active)")
+        self.signer_layout = QHBoxLayout()
+        self.signer_cb = QCheckBox(parent=self)
+        self.signer_layout.addWidget(self.signer_cb)
+        self.signer_order = QSpinBox(parent=self)
+        self.signer_order.setMinimum(0)
+        self.signer_layout.addWidget(self.signer_order)
+        self.signer_layout.addStretch()
+        self.addupdatelisteners(self.signer_layout)
+        form_layout.addRow(self.signer_label, self.signer_layout)
+        # TODO implement details; see https://github.com/PhonologicalCorpusTools/SLPAA/issues/18
+
+        self.source_label = QLabel("Source metadata (not yet active)")
+        self.source_layout = QHBoxLayout()
+        self.source_cb = QCheckBox(parent=self)
+        self.source_layout.addWidget(self.source_cb)
+        self.source_order = QSpinBox(parent=self)
+        self.source_order.setMinimum(0)
+        self.source_layout.addWidget(self.source_order)
+        self.source_layout.addStretch()
+        self.addupdatelisteners(self.source_layout)
+        form_layout.addRow(self.source_label, self.source_layout)
+        # TODO implement details; see https://github.com/PhonologicalCorpusTools/SLPAA/issues/18
+
+        self.recording_label = QLabel("Recording metadata (not yet active)")
+        self.recording_layout = QHBoxLayout()
+        self.recording_cb = QCheckBox(parent=self)
+        self.recording_layout.addWidget(self.recording_cb)
+        self.recording_order = QSpinBox(parent=self)
+        self.recording_order.setMinimum(0)
+        self.recording_layout.addWidget(self.recording_order)
+        self.recording_layout.addStretch()
+        self.addupdatelisteners(self.recording_layout)
+        form_layout.addRow(self.recording_label, self.recording_layout)
+        # TODO implement details; see https://github.com/PhonologicalCorpusTools/SLPAA/issues/18
+
+        self.delim_label = QLabel("Delimiter:")
+        self.delim_combo = EntryIDElementComboBox(datatype="delimiter", curvalue=str(self.qsettings_entryid.value('delimiter')), parent=self)
+        self.delim_combo.currentTextChanged.connect(self.updatepreview)
+        form_layout.addRow(self.delim_label, self.delim_combo)
+        
+        self.qsettings_entryid.endGroup()
+
+        self.preview_label = QLabel("Preview:")
+        self.preview_text = QLineEdit()
+        self.preview_text.setEnabled(False)
+        self.updatepreview(None)
+        form_layout.addRow(self.preview_label, self.preview_text)
+
+        main_layout.addLayout(form_layout)
+
+    def addupdatelisteners(self, layout):
+        index = layout.count() - 1
+        while index >= 0:
+            widget = layout.itemAt(index).widget()
+            if isinstance(widget, QSpinBox):
+                widget.valueChanged.connect(self.updatepreview)
+            elif isinstance(widget, EntryIDElementComboBox):
+                widget.currentTextChanged.connect(self.updatepreview)
+            elif isinstance(widget, QCheckBox):
+                widget.stateChanged.connect(self.updatepreview)
+            index -= 1
+
+    def check_ordering(self):
+        order_numbers = []
+        if self.counter_cb.isChecked():
+            order_numbers.append(self.counter_order.value())
+        if self.date_cb.isChecked():
+            order_numbers.append(self.date_order.value())
+
+        return len(set(order_numbers)) == len(order_numbers)  # no duplicates
+
+    def updatepreview(self, a0):
+        delim = self.delim_combo.get_value()
+
+        samplecounter = "1"
+        samplecounterstring = "0" * (self.counterdigits_spin.value() - len(samplecounter)) + samplecounter
+
+        sampledate = datetime.now()
+        sampledateformat = self.dateformat_combo.get_value()
+        # sampledatestring = sampledate.toString(sampledateformat)
+        sampledatestring = sampledate.strftime(sampledateformat)
+
+        # samplecoderstring = "coderinfo"
+        # samplesignerstring = "signerinfo"
+        # samplesourcestring = "sourceinfo"
+        # samplerecordingstring = "recordinginfo"
+
+        if self.check_ordering():
+            orders_strings = []
+            if self.counter_cb.isChecked():
+                orders_strings.append((self.counter_order.value(), samplecounterstring))
+            if self.date_cb.isChecked():
+                orders_strings.append((self.date_order.value(), sampledatestring))
+            # if self.coder_cb.isChecked():
+            #     orders_strings.append((self.coder_order.value(), samplecoderstring))
+            # if self.signer_cb.isChecked():
+            #     orders_strings.append((self.signer_order.value(), samplesignerstring))
+            # if self.source_cb.isChecked():
+            #     orders_strings.append((self.source_order.value(), samplesourcestring))
+            # if self.recording_cb.isChecked():
+            #     orders_strings.append((self.recording_order.value(), samplerecordingstring))
+            orders_strings.sort()
+            self.preview_text.setText(delim.join([string for (order, string) in orders_strings]))
+        else:
+            self.preview_text.setText("ordering conflict; no preview available")
+
+    def save_settings(self):
+        self.qsettings_entryid.beginGroup('entryid')
+        self.qsettings_entryid.setValue('delimiter', self.delim_combo.get_value())
+
+        self.qsettings_entryid.beginGroup('counter')
+        self.qsettings_entryid.setValue('visible', self.counter_cb.isChecked())
+        self.qsettings_entryid.setValue('order', self.counter_order.value() if self.counter_cb.isChecked() else 0)
+        self.qsettings_entryid.setValue('digits', self.counterdigits_spin.value())
+        self.qsettings_entryid.endGroup()  # counter
+
+        self.qsettings_entryid.beginGroup('date')
+        self.qsettings_entryid.setValue('visible', self.date_cb.isChecked())
+        self.qsettings_entryid.setValue('order', self.date_order.value() if self.date_cb.isChecked() else 0)
+        self.qsettings_entryid.setValue('format', self.dateformat_combo.get_value())
+        self.qsettings_entryid.endGroup()  # date
+
+        self.qsettings_entryid.endGroup()  # entryid
 
 
 # This tab facilitates user interaction with reminder-related settings in the preference dialog.
@@ -261,6 +484,9 @@ class PreferenceDialog(QDialog):
         self.display_tab = DisplayTab(settings, parent=self)
         tabs.addTab(self.display_tab, 'Display')
 
+        self.entryid_tab = EntryIDTab(settings, parent=self)
+        tabs.addTab(self.entryid_tab, 'Entry ID')
+
         self.reminder_tab = ReminderTab(settings, parent=self)
         tabs.addTab(self.reminder_tab, 'Reminder')
 
@@ -309,9 +535,9 @@ class PreferenceDialog(QDialog):
             xslotincompatibilities_msgbox = QMessageBox()
             xslotincompatibilities_msgbox.setText("Your new partial x-slot settings create incompatibilities with previously coded signs that used the old settings. What would you like to do?")
             discardbutton = QPushButton("Discard changes (keep old divisions)")
-            # TODO KV implement
+            # TODO implement
             newsignsonlybutton = QPushButton("Apply changes to new signs only (not yet implemented)")  # TODO KV [Tooltip / documentation explains: previously coded signs will have only the old x-slot options both visible and usable; any new signs added will have only the new x-slot options available.]
-            # TODO KV implement
+            # TODO implement
             allsignsbutton = QPushButton("Apply changes to all signs (not yet implemented)")  # TODO KV [Tooltip / documentation explains: previously coded signs will keep their coded x-slot selections if they are compatible with the new options, otherwise will lose their associations and need to be recoded; all signs (old and new) will have only the new x-slot options available]. [Add option here: output list of signs that had incompatibilities to a file? or mark in the corpus somehow?]
             xslotincompatibilities_msgbox.addButton(discardbutton, QMessageBox.DestructiveRole)
             xslotincompatibilities_msgbox.addButton(newsignsonlybutton, QMessageBox.ApplyRole)
@@ -324,10 +550,10 @@ class PreferenceDialog(QDialog):
                 # reset the partial x-slot fractions to whatever they were before
                 self.settings['signdefaults']['partial_xslots'] = beforedict
             elif result == newsignsonlybutton:
-                # TODO KV
+                # TODO
                 pass
             elif result == allsignsbutton:
-                # TODO KV
+                # TODO
                 pass
 
     def handle_button_click(self, button):
@@ -336,6 +562,7 @@ class PreferenceDialog(QDialog):
             self.reject()
         elif standard == QDialogButtonBox.Save:
             self.display_tab.save_settings()
+            self.entryid_tab.save_settings()
             self.reminder_tab.save_settings()
             self.signdefaults_tab.save_settings()
             self.location_tab.save_settings()

--- a/src/main/python/gui/signlevelinfospecification_view.py
+++ b/src/main/python/gui/signlevelinfospecification_view.py
@@ -63,7 +63,6 @@ class SignLevelInfoPanel(QFrame):
 
         entryid_label = QLabel("Entry ID:")
         self.entryid_value = QLineEdit()
-        self.entryid_value.setText(self.entryid().display_string())
         self.entryid_value.setEnabled(False)
         gloss_label = QLabel('Gloss:')
         self.gloss_edit = QLineEdit()
@@ -123,11 +122,17 @@ class SignLevelInfoPanel(QFrame):
 
         self.setLayout(main_layout)
 
-    def entryid(self):
+    def entryid_counter(self):
         if self.signlevelinfo is not None:
-            return self.signlevelinfo.entryid
+            return self.signlevelinfo.entryid.counter
         else:
-            return EntryID(counter=self.mainwindow.corpus.highestID+1, date=datetime.now())
+            return self.mainwindow.corpus.highestID+1
+
+    def entryid_string(self):
+        if self.signlevelinfo is not None:
+            return self.signlevelinfo.entryid.display_string()
+        else:
+            return ""
 
     def set_starting_focus(self):
         self.gloss_edit.setFocus()
@@ -136,7 +141,7 @@ class SignLevelInfoPanel(QFrame):
         if not signlevelinfo:
             signlevelinfo = self.signlevelinfo
         if self.signlevelinfo:
-            self.entryid_value.setText(self.signlevelinfo.entryid.display_string())
+            self.entryid_value.setText(self.entryid_string())
             self.gloss_edit.setText(signlevelinfo.gloss)
             self.lemma_edit.setText(signlevelinfo.lemma)
             self.source_edit.setText(signlevelinfo.source)
@@ -187,7 +192,7 @@ class SignLevelInfoPanel(QFrame):
                 self.created_display.set_datetime(newtime)
                 self.modified_display.set_datetime(newtime)
             return {
-                'entryid': self.entryid(),
+                'entryid': self.entryid_counter(),
                 'gloss': self.get_gloss(),
                 'lemma': self.lemma_edit.text(),
                 'source': self.source_edit.text(),

--- a/src/main/python/gui/signlevelinfospecification_view.py
+++ b/src/main/python/gui/signlevelinfospecification_view.py
@@ -22,6 +22,7 @@ from PyQt5.QtCore import (
 )
 
 from lexicon.lexicon_classes import SignLevelInformation
+from lexicon.module_classes import EntryID
 from gui.decorator import check_empty_gloss
 
 class SignLevelDateDisplay(QLabel):
@@ -44,7 +45,6 @@ class SignLevelDateDisplay(QLabel):
         self.set_datetime(None)
 
 
-# TODO KV redo the order in which init creates itself
 class SignLevelInfoPanel(QFrame):
 
     def __init__(self, signlevelinfo, **kwargs):
@@ -62,37 +62,35 @@ class SignLevelInfoPanel(QFrame):
         main_layout.setSpacing(5)
 
         entryid_label = QLabel("Entry ID:")
-        gloss_label = QLabel('Gloss:')
-        lemma_label = QLabel('Lemma:')
-        source_label = QLabel('Source:')
-        signer_label = QLabel('Signer:')
-        freq_label = QLabel('Frequency:')
-        coder_label = QLabel('Coder:')
-        created_label = QLabel('Date created:')
-        modified_label = QLabel('Date last modified:')
-        note_label = QLabel('Notes:')
-
         self.entryid_value = QLineEdit()
-        self.entryid_value.setText(self.entryid_string())
+        self.entryid_value.setText(self.entryid().display_string())
         self.entryid_value.setEnabled(False)
+        gloss_label = QLabel('Gloss:')
         self.gloss_edit = QLineEdit()
         self.gloss_edit.setFocusPolicy(Qt.StrongFocus)
+        lemma_label = QLabel('Lemma:')
         self.lemma_edit = QLineEdit()
+        source_label = QLabel('Source:')
         self.source_edit = QLineEdit()
+        signer_label = QLabel('Signer:')
         self.signer_edit = QLineEdit()
+        freq_label = QLabel('Frequency:')
         self.freq_edit = QLineEdit()
+        coder_label = QLabel('Coder:')
         self.coder_edit = QLineEdit()
+        created_label = QLabel('Date created:')
         self.created_display = SignLevelDateDisplay()
+        modified_label = QLabel('Date last modified:')
         self.modified_display = SignLevelDateDisplay()
+        note_label = QLabel('Notes:')
         self.note_edit = QPlainTextEdit()
-
-        self.fingerspelled_cb = QCheckBox()
         fingerspelled_label = QLabel('Fingerspelled:')
-        self.compoundsign_cb = QCheckBox()
+        self.fingerspelled_cb = QCheckBox()
         compoundsign_label = QLabel('Compound sign:')
+        self.compoundsign_cb = QCheckBox()
 
         handdominance_label = QLabel("Hand dominance:")
-        self.handdominance_buttongroup = QButtonGroup()  # parent=self)
+        self.handdominance_buttongroup = QButtonGroup()
         self.handdominance_l_radio = QRadioButton('Left')
         self.handdominance_l_radio.setProperty('hand', 'L')
         self.handdominance_r_radio = QRadioButton('Right')
@@ -129,15 +127,7 @@ class SignLevelInfoPanel(QFrame):
         if self.signlevelinfo is not None:
             return self.signlevelinfo.entryid
         else:
-            return self.mainwindow.corpus.highestID+1
-
-    def entryid_string(self, entryid_int=None):
-        numdigits = int(self.settings['display']['entryid_digits'])
-        if entryid_int is None:
-            entryid_int = self.entryid()
-        entryid_string = str(entryid_int)
-        entryid_string = "0"*(numdigits - len(entryid_string)) + entryid_string
-        return entryid_string
+            return EntryID(counter=self.mainwindow.corpus.highestID+1, date=datetime.now())
 
     def set_starting_focus(self):
         self.gloss_edit.setFocus()
@@ -146,7 +136,7 @@ class SignLevelInfoPanel(QFrame):
         if not signlevelinfo:
             signlevelinfo = self.signlevelinfo
         if self.signlevelinfo:
-            self.entryid_value.setText(self.entryid_string(signlevelinfo.entryid))
+            self.entryid_value.setText(self.signlevelinfo.entryid.display_string())
             self.gloss_edit.setText(signlevelinfo.gloss)
             self.lemma_edit.setText(signlevelinfo.lemma)
             self.source_edit.setText(signlevelinfo.source)
@@ -180,7 +170,6 @@ class SignLevelInfoPanel(QFrame):
         self.fingerspelled_cb.setChecked(False)
         self.compoundsign_cb.setChecked(False)
         self.set_handdominance(self.defaulthand)
-
 
     def set_handdominance(self, handdominance):
         if handdominance == 'R':

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -425,12 +425,21 @@ class Corpus:
     # see issue  # 242: https://github.com/PhonologicalCorpusTools/SLPAA/issues/242
     # this function should hopefully not be necessary forever, but for now I want to make sure that
     # functionality isn't affected by an incorrectly-saved value
-    def confirmhighestID(self, saveorload):
-        entryIDcounters = [s.signlevel_information.entryid.counter for s in self.signs]
+    def confirmhighestID(self, actionname):
+        entryIDcounters = [s.signlevel_information.entryid.counter for s in self.signs] or [0]
         max_entryID = max(entryIDcounters)
         if max_entryID > self.highestID:
-            logging.warn(" upon " + saveorload + " - highest entryID was not correct (recorded as " + str(self.highestID) + " but should have been " + str(max_entryID) + ");\nplease copy/paste this warning into an email to Kaili, along with the name of the corpus you're using")
+            logging.warn(" upon " + actionname + " - highest entryID was not correct (recorded as " + str(self.highestID) + " but should have been " + str(max_entryID) + ");\nplease copy/paste this warning into an email to Kaili, along with the name of the corpus you're using")
             self.highestID = max_entryID
+
+    def increaseminID(self, newmin):
+        entryIDcounters = [s.signlevel_information.entryid.counter for s in self.signs] or [0]
+        curmin = min(entryIDcounters)
+        if newmin > curmin:
+            increase_amount = newmin - curmin
+            for s in self.signs:
+                s.signlevel_information.entryid.counter += increase_amount
+            self.confirmhighestID("update")
 
     def serialize(self):
         # check and make sure the highest ID saved is equivalent to the actual highest entry ID

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -46,6 +46,8 @@ class Sign:
     Gloss in signlevel_information is used as the unique key
     """
     def __init__(self, signlevel_info=None, serializedsign=None):
+        if signlevel_info is not None:
+            signlevel_info.parentsign = self
         self._signlevel_information = signlevel_info
         self._signtype = None
         self._xslotstructure = XslotStructure()
@@ -64,7 +66,7 @@ class Sign:
         self.handconfigmodulenumbers = {}
 
         if serializedsign is not None:
-            self._signlevel_information = SignLevelInformation(serializedsignlevelinfo=serializedsign['signlevel'])
+            self._signlevel_information = SignLevelInformation(serializedsignlevelinfo=serializedsign['signlevel'], parentsign=self)
             signtype = serializedsign['type']
             self._signtype = Signtype(signtype.specslist) if signtype is not None else None
             if hasattr(serializedsign['type'], '_addedinfo'):  # for backward compatibility
@@ -311,6 +313,7 @@ class Sign:
     @signlevel_information.setter
     def signlevel_information(self, signlevelinfo):
         self._signlevel_information = signlevelinfo  # SignLevelInformation(signlevelinfo)
+        self._signlevel_information.parentsign = self
 
     @property
     def location(self):

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -295,10 +295,10 @@ class Sign:
         self.relationmodules = unserialized
 
     def __hash__(self):
-        return hash(self.signlevel_information.entryid)
+        return hash(self.signlevel_information.entryid.display_string())  # TODO KV how are equality/keys determined?
 
     # Ref: https://eng.lyft.com/hashing-and-equality-in-python-2ea8c738fb9d
-    def __eq__(self, other):
+    def __eq__(self, other):  # TODO KV how are equality/keys determined?
         return isinstance(other, Sign) and self.signlevel_information.entryid == other.signlevel_information.entryid
 
     def __repr__(self):
@@ -412,7 +412,7 @@ class Corpus:
             # check and make sure the highest ID saved is equivalent to the actual highest entry ID
             # see issue #242: https://github.com/PhonologicalCorpusTools/SLPAA/issues/242
             self.confirmhighestID("load")
-            self.add_missing_paths() # Another backwards compatibility function for movement and location
+            self.add_missing_paths()  # Another backwards compatibility function for movement and location
         else:
             self.name = name
             self.signs = signs if signs else set()
@@ -426,8 +426,8 @@ class Corpus:
     # this function should hopefully not be necessary forever, but for now I want to make sure that
     # functionality isn't affected by an incorrectly-saved value
     def confirmhighestID(self, saveorload):
-        entryIDs = [s.signlevel_information.entryid for s in self.signs]
-        max_entryID = max(entryIDs)
+        entryIDcounters = [s.signlevel_information.entryid.counter for s in self.signs]
+        max_entryID = max(entryIDcounters)
         if max_entryID > self.highestID:
             logging.warn(" upon " + saveorload + " - highest entryID was not correct (recorded as " + str(self.highestID) + " but should have been " + str(max_entryID) + ");\nplease copy/paste this warning into an email to Kaili, along with the name of the corpus you're using")
             self.highestID = max_entryID
@@ -482,7 +482,7 @@ class Corpus:
 
     def add_sign(self, new_sign):
         self.signs.add(new_sign)
-        self.highestID = max([new_sign.signlevel_information.entryid, self.highestID])
+        self.highestID = max(new_sign.signlevel_information.entryid.counter, self.highestID)
 
     def remove_sign(self, trash_sign):
         self.signs.remove(trash_sign)


### PR DESCRIPTION
EntryID is now a class instead of just a counter. An EntryID is displayed pulling data on-the-fly from application QSettings and from its parent Sign, to combine various attributes (date, counter, etc) in a user-specific order, with a user-selected delimiter.

We can also set the minimum counter value for a corpus-- either by the user when first creating a blank corpus, or programmatically for instance if merging corpora.