### PR TITLE
283 add entryid flexibilityfunctionality

### DIFF
--- a/src/main/python/gui/decorator.py
+++ b/src/main/python/gui/decorator.py
@@ -42,24 +42,6 @@ def check_unsaved_change(func):
     return wrapper_check_unsaved_change
 
 
-def check_date_format(func):
-    @functools.wraps(func)
-    def wrapper_check_date_format(self, *args, **kwargs):
-        if len(self.update_edit.text().split(sep='-')) != 3:
-            QMessageBox.critical(self, 'Date Format Error',
-                                 'Please make sure your date follows the format of YYYY-MM-DD.')
-            return
-        try:
-            year, month, day = self.update_edit.text().split(sep='-')
-            date(int(year), int(month), int(day))
-        except ValueError as error:
-            QMessageBox.critical(self, 'Date Format Error', str(error))
-            return
-        else:
-            return func(self, *args, **kwargs)
-    return wrapper_check_date_format
-
-
 def check_empty_gloss(func):
     @functools.wraps(func)
     def wrapper_check_empty_gloss(self, *args, **kwargs):

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -596,7 +596,8 @@ class MainWindow(QMainWindow):
         self.app_qsettings.beginGroup('storage')
         self.app_settings['storage']['recent_folder'] = self.app_qsettings.value(
             'recent_folder',
-            defaultValue=os.path.expanduser('~/Documents'))
+            defaultValue=os.path.expanduser('~/Documents')
+        )
         self.app_settings['storage']['corpora'] = self.app_qsettings.value(
             'corpora',
             defaultValue=os.path.normpath(os.path.join(os.path.expanduser('~/Documents'), 'PCT', 'SLP-AA', 'CORPORA'))
@@ -611,56 +612,56 @@ class MainWindow(QMainWindow):
         self.app_settings['display']['size'] = self.app_qsettings.value('size', defaultValue=QSize(2000, 1200))
         self.app_settings['display']['position'] = self.app_qsettings.value('position', defaultValue=QPoint(0, 23))
 
-        self.app_settings['display']['sub_corpus_show'] = bool(self.app_qsettings.value('sub_corpus_show', defaultValue=True))
+        self.app_settings['display']['sub_corpus_show'] = self.app_qsettings.value('sub_corpus_show', defaultValue=True, type=bool)
         self.app_settings['display']['sub_corpus_pos'] = self.app_qsettings.value('sub_corpus_pos', defaultValue=QPoint(0, 0))
         self.app_settings['display']['sub_corpus_size'] = self.app_qsettings.value('sub_corpus_size', defaultValue=QSize(340, 700))
 
-        self.app_settings['display']['sub_signlevelmenu_show'] = bool(self.app_qsettings.value('sub_signlevelmenu_show', defaultValue=True))
+        self.app_settings['display']['sub_signlevelmenu_show'] = self.app_qsettings.value('sub_signlevelmenu_show', defaultValue=True, type=bool)
         self.app_settings['display']['sub_signlevelmenu_pos'] = self.app_qsettings.value('sub_signlevelmenu_pos', defaultValue=QPoint(340, 0))
         self.app_settings['display']['sub_signlevelmenu_size'] = self.app_qsettings.value('sub_signlevelmenu_size', defaultValue=QSize(320, 700))
 
-        self.app_settings['display']['sub_visualsummary_show'] = bool(self.app_qsettings.value('sub_visualsummary_show', defaultValue=True))
+        self.app_settings['display']['sub_visualsummary_show'] = self.app_qsettings.value('sub_visualsummary_show', defaultValue=True, type=bool)
         self.app_settings['display']['sub_visualsummary_pos'] = self.app_qsettings.value('sub_visualsummary_pos', defaultValue=QPoint(660, 0))
         self.app_settings['display']['sub_visualsummary_size'] = self.app_qsettings.value('sub_visualsummary_size', defaultValue=QSize(1200, 900))
 
         self.app_settings['display']['sig_figs'] = self.app_qsettings.value('sig_figs', defaultValue=2, type=int)
-        self.app_settings['display']['tooltips'] = bool(self.app_qsettings.value('tooltips', defaultValue=True))
+        self.app_settings['display']['tooltips'] = self.app_qsettings.value('tooltips', defaultValue=True, type=bool)
         # backward compatibility:
         #   entryid_digits used to be under the display section but has now (20240229) moved to a separate entryid section
         #   if this setting was saved under display, make sure it's re-stored in entryid and that 'display/entryid_digits' is removed
         existing_entryid_digits = None
         if self.app_qsettings.contains('entryid_digits'):
-            existing_entryid_digits = self.app_qsettings.value('entryid_digits')
+            existing_entryid_digits = self.app_qsettings.value('entryid_digits', type=int)
             self.app_qsettings.remove('entryid_digits')
         self.app_qsettings.endGroup()  # display
 
         self.app_qsettings.beginGroup('entryid')
         self.app_qsettings.beginGroup('counter')
-        self.app_qsettings.setValue('visible', bool(self.app_qsettings.value('visible', defaultValue=True, type=bool)))
-        self.app_qsettings.setValue('order', int(self.app_qsettings.value('order', defaultValue=0, type=int)))
-        counterdigits = existing_entryid_digits or int(self.app_qsettings.value('digits', defaultValue=4, type=int))
+        self.app_qsettings.setValue('visible', self.app_qsettings.value('visible', defaultValue=True, type=bool))
+        self.app_qsettings.setValue('order', self.app_qsettings.value('order', defaultValue=0, type=int))
+        counterdigits = existing_entryid_digits or self.app_qsettings.value('digits', defaultValue=4, type=int)
         self.app_qsettings.setValue('digits', counterdigits)
         self.app_qsettings.endGroup()  # counter
         self.app_qsettings.beginGroup('date')
-        self.app_qsettings.setValue('visible', bool(self.app_qsettings.value('visible', defaultValue=False, type=bool)))
-        self.app_qsettings.setValue('order', int(self.app_qsettings.value('order', defaultValue=0, type=int)))
-        self.app_qsettings.setValue('format', str(self.app_qsettings.value('format', defaultValue='YYYY-MM', type=str)))
+        self.app_qsettings.setValue('visible', self.app_qsettings.value('visible', defaultValue=False, type=bool))
+        self.app_qsettings.setValue('order', self.app_qsettings.value('order', defaultValue=0, type=int))
+        self.app_qsettings.setValue('format', self.app_qsettings.value('format', defaultValue='YYYY-MM', type=str))
         self.app_qsettings.endGroup()  # date
         self.app_qsettings.setValue('delimiter', self.app_qsettings.value('delimiter', defaultValue='_', type=str))
         self.app_qsettings.endGroup()  # entryid
 
         self.app_qsettings.beginGroup('metadata')
-        self.app_settings['metadata']['coder'] = self.app_qsettings.value('coder', defaultValue='NEWUSERNAME')
+        self.app_settings['metadata']['coder'] = self.app_qsettings.value('coder', defaultValue='NEWUSERNAME', type=str)
         self.app_qsettings.endGroup()  # metadata
 
         self.app_qsettings.beginGroup('reminder')
-        self.app_settings['reminder']['overwrite'] = bool(self.app_qsettings.value('overwrite', defaultValue=True))
+        self.app_settings['reminder']['overwrite'] = self.app_qsettings.value('overwrite', defaultValue=True, type=bool)
         self.app_qsettings.endGroup()  # reminder
 
         self.app_qsettings.beginGroup('signdefaults')
-        self.app_settings['signdefaults']['handdominance'] = self.app_qsettings.value('handdominance', defaultValue='R')
+        self.app_settings['signdefaults']['handdominance'] = self.app_qsettings.value('handdominance', defaultValue='R', type=str)
         self.app_settings['signdefaults']['signtype'] = self.app_qsettings.value('signtype', defaultValue='none')
-        self.app_settings['signdefaults']['xslot_generation'] = self.app_qsettings.value('xslot_generation', defaultValue='none')
+        self.app_settings['signdefaults']['xslot_generation'] = self.app_qsettings.value('xslot_generation', defaultValue='none', type=str)
         self.app_qsettings.beginGroup('partial_xslots')
         self.app_settings['signdefaults']['partial_xslots'] = defaultdict(dict)
         self.app_settings['signdefaults']['partial_xslots'][str(Fraction(1, 2))] = \
@@ -698,6 +699,12 @@ class MainWindow(QMainWindow):
         self.app_qsettings.setValue('sub_corpus_show', not self.sub_corpus.isHidden())
         self.app_qsettings.setValue('sub_corpus_pos', self.sub_corpus.pos())
         self.app_qsettings.setValue('sub_corpus_size', self.sub_corpus.size())
+        self.app_qsettings.setValue('sub_signlevelmenu_show', not self.sub_signlevelmenu.isHidden())
+        self.app_qsettings.setValue('sub_signlevelmenu_pos', self.sub_signlevelmenu.pos())
+        self.app_qsettings.setValue('sub_signlevelmenu_size', self.sub_signlevelmenu.size())
+        self.app_qsettings.setValue('sub_visualsummary_show', not self.sub_visualsummary.isHidden())
+        self.app_qsettings.setValue('sub_visualsummary_pos', self.sub_visualsummary.pos())
+        self.app_qsettings.setValue('sub_visualsummary_size', self.sub_visualsummary.size())
 
         self.app_qsettings.setValue('sig_figs', self.app_settings['display']['sig_figs'])
         self.app_qsettings.setValue('tooltips', self.app_settings['display']['tooltips'])

--- a/src/main/python/gui/preference_dialog.py
+++ b/src/main/python/gui/preference_dialog.py
@@ -98,7 +98,7 @@ class EntryIDTab(QWidget):
         main_layout = QVBoxLayout()
         self.setLayout(main_layout)
 
-        self.instructions_label = QLabel("Select which elements, and in which order, will comprise the Entry ID for each sign.")
+        self.instructions_label = QLabel("Select which elements, and in which order, will be displayed as the Entry ID for each sign.")
         main_layout.addWidget(self.instructions_label)
         self.qsettings_entryid = QSettings()  # organization name & application name were set in MainWindow.__init__()
         self.qsettings_entryid.beginGroup('entryid')
@@ -108,18 +108,19 @@ class EntryIDTab(QWidget):
         self.counter_label = QLabel("Sequential number of sign in corpus")
         self.counter_layout = QHBoxLayout()
         self.counter_cb = QCheckBox(parent=self)
-        self.counter_cb.setChecked(bool(self.qsettings_entryid.value('counter/visible')))
+        self.counter_cb.setChecked(self.qsettings_entryid.value('counter/visible', type=bool))
         self.counter_layout.addWidget(self.counter_cb)
         self.counter_order = QSpinBox(parent=self)
         self.counter_order.setMinimum(0)
-        self.counter_order.setValue(int(self.qsettings_entryid.value('counter/order')))
+        if self.counter_cb.isChecked():
+            self.counter_order.setValue(self.qsettings_entryid.value('counter/order', type=int))
         self.counter_layout.addWidget(self.counter_order)
         self.counter_layout.addStretch()
         self.counterdigits_label = QLabel("Min # of displayed digits:")
         self.counter_layout.addWidget(self.counterdigits_label)
         self.counterdigits_spin = QSpinBox(parent=self)
         self.counterdigits_spin.setMinimum(1)
-        self.counterdigits_spin.setValue(int(self.qsettings_entryid.value('counter/digits')))
+        self.counterdigits_spin.setValue(self.qsettings_entryid.value('counter/digits', type=int))
         self.counter_layout.addWidget(self.counterdigits_spin)
         self.addupdatelisteners(self.counter_layout)
         form_layout.addRow(self.counter_label, self.counter_layout)
@@ -127,17 +128,17 @@ class EntryIDTab(QWidget):
         self.date_label = QLabel("Date sign created")
         self.date_layout = QHBoxLayout()
         self.date_cb = QCheckBox(parent=self)
-        self.date_cb.setChecked(bool(self.qsettings_entryid.value('date/visible')))
+        self.date_cb.setChecked(self.qsettings_entryid.value('date/visible', type=bool))
         self.date_layout.addWidget(self.date_cb)
         self.date_order = QSpinBox(parent=self)
         self.date_order.setMinimum(0)
-        self.date_order.setValue(int(self.qsettings_entryid.value('date/order')))
+        if self.date_cb.isChecked():
+            self.date_order.setValue(self.qsettings_entryid.value('date/order', type=int))
         self.date_layout.addWidget(self.date_order)
         self.date_layout.addStretch()
         self.dateformat_label = QLabel("Format:")
         self.date_layout.addWidget(self.dateformat_label)
-        tempformatvalue = str(self.qsettings_entryid.value('date/format'))
-        self.dateformat_combo = EntryIDElementComboBox(datatype="dateformat", curvalue=str(self.qsettings_entryid.value('date/format')), parent=self)
+        self.dateformat_combo = EntryIDElementComboBox(datatype="dateformat", curvalue=self.qsettings_entryid.value('date/format', type=str), parent=self)
         self.date_layout.addWidget(self.dateformat_combo)
         self.addupdatelisteners(self.date_layout)
         form_layout.addRow(self.date_label, self.date_layout)
@@ -191,7 +192,7 @@ class EntryIDTab(QWidget):
         # TODO implement details; see https://github.com/PhonologicalCorpusTools/SLPAA/issues/18
 
         self.delim_label = QLabel("Delimiter:")
-        self.delim_combo = EntryIDElementComboBox(datatype="delimiter", curvalue=str(self.qsettings_entryid.value('delimiter')), parent=self)
+        self.delim_combo = EntryIDElementComboBox(datatype="delimiter", curvalue=self.qsettings_entryid.value('delimiter', type=str), parent=self)
         self.delim_combo.currentTextChanged.connect(self.updatepreview)
         form_layout.addRow(self.delim_label, self.delim_combo)
         
@@ -262,23 +263,23 @@ class EntryIDTab(QWidget):
             self.preview_text.setText("ordering conflict; no preview available")
 
     def save_settings(self):
-        self.qsettings_entryid.beginGroup('entryid')
-        self.qsettings_entryid.setValue('delimiter', self.delim_combo.get_value())
+        if self.check_ordering():
+            self.qsettings_entryid.beginGroup('entryid')
+            self.qsettings_entryid.setValue('delimiter', self.delim_combo.get_value())
 
-        self.qsettings_entryid.beginGroup('counter')
-        self.qsettings_entryid.setValue('visible', self.counter_cb.isChecked())
-        self.qsettings_entryid.setValue('order', self.counter_order.value() if self.counter_cb.isChecked() else 0)
-        self.qsettings_entryid.setValue('digits', self.counterdigits_spin.value())
-        self.qsettings_entryid.endGroup()  # counter
+            self.qsettings_entryid.setValue('counter/visible', self.counter_cb.isChecked())
+            self.qsettings_entryid.setValue('counter/order', self.counter_order.value() if self.counter_cb.isChecked() else 0)
+            self.qsettings_entryid.setValue('counter/digits', self.counterdigits_spin.value())
 
-        self.qsettings_entryid.beginGroup('date')
-        self.qsettings_entryid.setValue('visible', self.date_cb.isChecked())
-        self.qsettings_entryid.setValue('order', self.date_order.value() if self.date_cb.isChecked() else 0)
-        self.qsettings_entryid.setValue('format', self.dateformat_combo.get_value())
-        self.qsettings_entryid.endGroup()  # date
+            self.qsettings_entryid.setValue('date/visible', self.date_cb.isChecked())
+            self.qsettings_entryid.setValue('date/order', self.date_order.value() if self.date_cb.isChecked() else 0)
+            self.qsettings_entryid.setValue('date/format', self.dateformat_combo.get_value())
 
-        self.qsettings_entryid.endGroup()  # entryid
-
+            self.qsettings_entryid.endGroup()  # entryid
+            self.qsettings_entryid.sync()
+            return ""
+        else:
+            return "[Entry ID tab] Ordering conflict: Please make sure there are no duplicated order values."
 
 # This tab facilitates user interaction with reminder-related settings in the preference dialog.
 class ReminderTab(QWidget):
@@ -561,10 +562,14 @@ class PreferenceDialog(QDialog):
         if standard == QDialogButtonBox.Cancel:
             self.reject()
         elif standard == QDialogButtonBox.Save:
-            self.display_tab.save_settings()
-            self.entryid_tab.save_settings()
-            self.reminder_tab.save_settings()
-            self.signdefaults_tab.save_settings()
-            self.location_tab.save_settings()
-            self.prefs_saved.emit()
-            self.accept()
+            errormessages = []
+            for tab in [self.display_tab, self.entryid_tab, self.reminder_tab, self.signdefaults_tab, self.location_tab]:
+                errorstring = tab.save_settings()
+                if errorstring:
+                    errormessages.append(errorstring)
+            if len(errormessages) > 0:
+                QMessageBox.critical(self, "Error saving preferences", "\n".join(errormessages))
+                return
+            else:
+                self.prefs_saved.emit()
+                self.accept()

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -191,7 +191,7 @@ class EntryID:
             if qsettings.value('entryid/' + attr + '/visible', type=bool):
                 orders_strings.append((qsettings.value('entryid/' + attr + '/order', type=int), self.getattributestringfromname(attr, qsettings)))
         orders_strings.sort()
-        return qsettings.value('entryid/delimiter', type=str).join([string for (order, string) in orders_strings])
+        return qsettings.value('entryid/delimiter', type=str).join([string for (order, string) in orders_strings]) or "[Entry ID is blank]"
 
     # == check compares the displayed strings
     def __eq__(self, other):

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -173,10 +173,10 @@ class EntryID:
 
     def getattributestringfromname(self, attr_name, qsettings):
         if attr_name == 'date':
-            return "" if self.date is None else self.date.strftime(qsettings.value('entryid/date/format'))
+            return "" if self.date is None else self.date.strftime(qsettings.value('entryid/date/format', type=str))
         elif attr_name == 'counter':
             counter_string = str(self.counter)
-            return "0" * (qsettings.value('entryid/counter/digits') - len(counter_string)) + counter_string
+            return "0" * (qsettings.value('entryid/counter/digits', type=int) - len(counter_string)) + counter_string
         elif attr_name in dir(self):
             # assuming we have a @property function for this attribute and it doesn't need any additional formatting
             return getattr(self, attr_name)
@@ -188,10 +188,10 @@ class EntryID:
 
         orders_strings = []
         for attr in ['counter', 'date']:  # could these come from 'attr in dir(self)' instead?
-            if qsettings.value('entryid/' + attr + '/visible'):
-                orders_strings.append((qsettings.value('entryid/' + attr + '/order'), self.getattributestringfromname(attr, qsettings)))
+            if qsettings.value('entryid/' + attr + '/visible', type=bool):
+                orders_strings.append((qsettings.value('entryid/' + attr + '/order', type=int), self.getattributestringfromname(attr, qsettings)))
         orders_strings.sort()
-        return qsettings.value('entryid/delimiter').join([string for (order, string) in orders_strings])
+        return qsettings.value('entryid/delimiter', type=str).join([string for (order, string) in orders_strings])
 
     # == check compares the displayed strings
     def __eq__(self, other):


### PR DESCRIPTION
 - ensure EntryID settings persist correctly
 - ensure settings for which subwindows are visible are saved correctly
 - add a note for when Entry ID is blank (user has de-selected all potential components)