### PR TITLE
re-added the info field to the top of the corpus view

### DIFF
--- a/src/main/python/gui/corpus_view.py
+++ b/src/main/python/gui/corpus_view.py
@@ -24,11 +24,19 @@ from lexicon.lexicon_classes import Sign
 class CorpusDisplay(QWidget):
     selected_sign = pyqtSignal(Sign)
 
-    def __init__(self, **kwargs):
+    def __init__(self, corpusfilename="", **kwargs):
         super().__init__(**kwargs)
 
         main_layout = QVBoxLayout()
         self.setLayout(main_layout)
+
+        filename_layout = QHBoxLayout()
+        corpusfile_label = QLabel("Corpus file:")
+        self.corpusfile_edit = QLineEdit(corpusfilename or "not yet saved")
+        self.corpusfile_edit.setEnabled(False)
+        filename_layout.addWidget(corpusfile_label)
+        filename_layout.addWidget(self.corpusfile_edit)
+        main_layout.addLayout(filename_layout)
 
         self.corpus_model = CorpusModel(parent=self)
         self.corpus_view = QListView(parent=self)
@@ -98,6 +106,8 @@ class CorpusDisplay(QWidget):
         self.corpus_view.clearSelection()
 
     def clear(self):
+        self.corpusfile_edit.setText("not yet saved")
+
         self.corpus_model.clear()
         self.corpus_model.layoutChanged.emit()
         self.corpus_view.clearSelection()

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -313,7 +313,8 @@ class MainWindow(QMainWindow):
         menu_analysis_beta = main_menu.addMenu("&Analysis functions (beta)")
         menu_analysis_beta.addAction(action_count_xslots)
 
-        self.corpus_display = CorpusDisplay(parent=self)
+        corpusfilename = os.path.split(self.corpus.path)[1] if self.corpus else ""
+        self.corpus_display = CorpusDisplay(corpusfilename=corpusfilename, parent=self)
         self.corpus_display.selected_sign.connect(self.handle_sign_selected)
 
         self.corpus_scroll = QScrollArea(parent=self)
@@ -839,6 +840,7 @@ class MainWindow(QMainWindow):
     def on_action_save(self, clicked):
         if self.corpus.path:
             self.save_corpus_binary()
+            self.corpus_display.corpusfile_edit.setText(os.path.split(self.corpus.path)[1])
 
         self.unsaved_changes = False
         self.undostack.clear()
@@ -857,6 +859,7 @@ class MainWindow(QMainWindow):
                 self.app_settings['storage']['recent_folder'] = folder
 
             self.save_corpus_binary()
+            self.corpus_display.corpusfile_edit.setText(os.path.split(self.corpus.path)[1])
 
             self.unsaved_changes = False
             self.undostack.clear()
@@ -910,6 +913,7 @@ class MainWindow(QMainWindow):
             self.app_settings['storage']['recent_folder'] = folder
 
         self.corpus = self.load_corpus_binary(file_name)
+        self.corpus_display.corpusfile_edit.setText(os.path.split(self.corpus.path)[1])
         self.corpus_display.updated_signs(self.corpus.signs)
         if len(self.corpus.signs) > 0:
             self.corpus_display.selected_sign.emit((list(self.corpus.signs))[0])


### PR DESCRIPTION
but now it displays the filename (no folder or path info) instead of - as previously - the corpus name (... which doesn't exist anymore)