### PR TITLE
add a single point of reference for delimiter to use between glosses

### DIFF
--- a/src/main/python/gui/bodypartspecification_dialog.py
+++ b/src/main/python/gui/bodypartspecification_dialog.py
@@ -18,7 +18,7 @@ from PyQt5.QtCore import (
 from gui.modulespecification_widgets import AddedInfoPushButton
 from gui.locationspecification_view import LocationOptionsSelectionPanel
 from models.location_models import BodypartTreeModel
-from lexicon.module_classes import AddedInfo, delimiter, BodypartInfo
+from lexicon.module_classes import AddedInfo, treepathdelimiter, BodypartInfo
 from constant import HAND, ARM, LEG
 from serialization_classes import LocationTreeSerializable
 import logging

--- a/src/main/python/gui/locationspecification_view.py
+++ b/src/main/python/gui/locationspecification_view.py
@@ -38,7 +38,7 @@ from PyQt5.QtGui import (
     QPixmap
 )
 
-from lexicon.module_classes import delimiter, LocationModule, PhonLocations, userdefinedroles as udr
+from lexicon.module_classes import treepathdelimiter, LocationModule, PhonLocations, userdefinedroles as udr
 from models.location_models import LocationTreeItem, LocationTableModel, LocationTreeModel, \
     LocationType, LocationPathsProxyModel
 from serialization_classes import LocationTreeSerializable
@@ -63,7 +63,7 @@ class LocnTreeSearchComboBox(QComboBox):
             if self.currentText():
                 itemstoselect = gettreeitemsinpath(self.parent().treemodel,
                                                    self.currentText(),
-                                                   delim=delimiter)
+                                                   delim=treepathdelimiter)
                 for item in itemstoselect:
                     if item.checkState() == Qt.Unchecked:
                         item.setCheckState(Qt.PartiallyChecked)
@@ -88,9 +88,9 @@ class LocnTreeSearchComboBox(QComboBox):
                     elif foundcurrententry and self.lasttextentry.lower() in completionoption.lower() \
                             and not completionoption.lower().startswith(self.lastcompletedentry.lower()):
                         foundnextentry = True
-                        if delimiter in completionoption[len(self.lasttextentry):]:
+                        if treepathdelimiter in completionoption[len(self.lasttextentry):]:
                             self.setEditText(
-                                completionoption[:completionoption.index(delimiter, len(self.lasttextentry)) + 1])
+                                completionoption[:completionoption.index(treepathdelimiter, len(self.lasttextentry)) + 1])
                         else:
                             self.setEditText(completionoption)
                         self.lastcompletedentry = self.currentText()
@@ -103,9 +103,9 @@ class LocnTreeSearchComboBox(QComboBox):
                     completionoption = self.completer().currentCompletion()
                     if completionoption.lower().startswith(self.lasttextentry.lower()):
                         foundnextentry = True
-                        if delimiter in completionoption[len(self.lasttextentry):]:
+                        if treepathdelimiter in completionoption[len(self.lasttextentry):]:
                             self.setEditText(
-                                completionoption[:completionoption.index(delimiter, len(self.lasttextentry)) + 1])
+                                completionoption[:completionoption.index(treepathdelimiter, len(self.lasttextentry)) + 1])
                         else:
                             self.setEditText(completionoption)
                         self.lastcompletedentry = self.currentText()

--- a/src/main/python/gui/movementspecification_view.py
+++ b/src/main/python/gui/movementspecification_view.py
@@ -21,7 +21,7 @@ from PyQt5.QtCore import (
     QEvent,
 )
 
-from lexicon.module_classes import delimiter, userdefinedroles as udr, MovementModule
+from lexicon.module_classes import treepathdelimiter, userdefinedroles as udr, MovementModule
 from models.movement_models import MovementTreeModel, MovementPathsProxyModel
 from serialization_classes import MovementTreeSerializable
 from gui.modulespecification_widgets import AddedInfoContextMenu, ModuleSpecificationPanel, TreeListView, TreePathsListItemDelegate
@@ -46,7 +46,7 @@ class MvmtTreeSearchComboBox(QComboBox):
                 self.parent().treedisplay.collapseAll()
                 itemstoselect = gettreeitemsinpath(self.parent().treemodel,
                                                    self.currentText(),
-                                                   delim=delimiter)
+                                                   delim=treepathdelimiter)
                 for item in itemstoselect:
                     if item.checkState() == Qt.Unchecked:
                         item.setCheckState(Qt.PartiallyChecked)
@@ -70,9 +70,9 @@ class MvmtTreeSearchComboBox(QComboBox):
                         foundcurrententry = True
                     elif foundcurrententry and self.lasttextentry.lower() in completionoption.lower() and not completionoption.lower().startswith(self.lastcompletedentry.lower()):
                         foundnextentry = True
-                        if delimiter in completionoption[len(self.lasttextentry):]:
+                        if treepathdelimiter in completionoption[len(self.lasttextentry):]:
                             self.setEditText(
-                                completionoption[:completionoption.index(delimiter, len(self.lasttextentry)) + 1])
+                                completionoption[:completionoption.index(treepathdelimiter, len(self.lasttextentry)) + 1])
                         else:
                             self.setEditText(completionoption)
                         self.lastcompletedentry = self.currentText()
@@ -85,9 +85,9 @@ class MvmtTreeSearchComboBox(QComboBox):
                     completionoption = self.completer().currentCompletion()
                     if completionoption.lower().startswith(self.lasttextentry.lower()):
                         foundnextentry = True
-                        if delimiter in completionoption[len(self.lasttextentry):]:
+                        if treepathdelimiter in completionoption[len(self.lasttextentry):]:
                             self.setEditText(
-                                completionoption[:completionoption.index(delimiter, len(self.lasttextentry)) + 1])
+                                completionoption[:completionoption.index(treepathdelimiter, len(self.lasttextentry)) + 1])
                         else:
                             self.setEditText(completionoption)
                         self.lastcompletedentry = self.currentText()

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -49,9 +49,10 @@ from gui.helper_widget import CollapsibleSection, ToggleSwitch
 from constant import DEFAULT_LOCATION_POINTS, HAND, ARM, LEG, ARTICULATOR_ABBREVS
 from gui.xslotspecification_view import XslotSelectorDialog
 from lexicon.module_classes import TimingPoint, TimingInterval, ModuleTypes
-from lexicon.lexicon_classes import Sign
+from lexicon.lexicon_classes import Sign, glossesdelimiter
 from gui.modulespecification_dialog import ModuleSelectorDialog
 from gui.xslot_graphics import XslotRect, XslotRectModuleButton, SignSummaryScene, XslotEllipseModuleButton
+
 
 
 # TODO KV there are two classes with this name-- are they exactly the same?
@@ -325,7 +326,7 @@ class SignSummaryPanel(QScrollArea):
         signleveltext = QGraphicsTextItem()
         signleveltext.setPlainText("Welcome! Add a new sign to get started.")
         if self.sign is not None:
-            signleveltext.setPlainText(" / ".join(self.sign.signlevel_information.gloss)
+            signleveltext.setPlainText(glossesdelimiter.join(self.sign.signlevel_information.gloss)
                                        + " - " + self.sign.signlevel_information.entryid.display_string())
         signleveltext.setPos(self.x_offset, self.current_y)
         self.current_y += 30
@@ -861,7 +862,7 @@ class SignLevelMenuPanel(QScrollArea):
     @sign.setter
     def sign(self, sign):
         self._sign = sign
-        self.signgloss_label.setText("Sign: " + "/".join(sign.signlevel_information.gloss) if sign else "")
+        self.signgloss_label.setText("Sign: " + glossesdelimiter.join(sign.signlevel_information.gloss) if sign else "")
 
     def clear(self):
         self._sign = None

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from serialization_classes import LocationModuleSerializable, MovementModuleSerializable, RelationModuleSerializable
-from lexicon.module_classes import SignLevelInformation, MovementModule, AddedInfo, LocationModule, ModuleTypes, BodypartInfo, RelationX, RelationY, Direction, RelationModule, delimiter
+from lexicon.module_classes import SignLevelInformation, MovementModule, AddedInfo, LocationModule, ModuleTypes, BodypartInfo, RelationX, RelationY, Direction, RelationModule, treepathdelimiter
 from gui.signtypespecification_view import Signtype
 from gui.xslotspecification_view import XslotStructure
 from models.movement_models import MovementTreeModel
@@ -10,6 +10,7 @@ from models.location_models import LocationTreeModel, BodypartTreeModel
 from constant import HAND, ARM, LEG
 
 NULL = '\u2205'
+glossesdelimiter = " / "
 
 
 def empty_copy(obj):
@@ -311,7 +312,7 @@ class Sign:
         return isinstance(other, Sign) and self.signlevel_information.entryid.counter == other.signlevel_information.entryid.counter
 
     def __repr__(self):
-        glosses_string = " / ".join(self.signlevel_information.gloss)
+        glosses_string = glossesdelimiter.join(self.signlevel_information.gloss)
         return '<SIGN: ' + repr(glosses_string) + ' - ' + repr(self.signlevel_information.entryid) + '>'
 
     @property
@@ -553,7 +554,7 @@ class Corpus:
                 logging.warning(label+": bad backwards compatibility for " + oldpath)
                 
             for path in paths_to_add:
-                newpath = delimiter.join(path)
+                newpath = treepathdelimiter.join(path)
                 correctionsdict[type][entryidcounter][newpath] = oldpath
                 newpaths.append(newpath)
         thisdict = correctionsdict[type][entryidcounter]
@@ -576,7 +577,7 @@ class Corpus:
         nodes = []
         curr = ""
         for c in item:
-            if (c is not delimiter):
+            if (c is not treepathdelimiter):
                 curr = curr + c
             else:
                 nodes.append(curr)

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -11,7 +11,7 @@ from PyQt5.QtCore import (
 from constant import NULL, PREDEFINED_MAP, HAND, ARM, LEG
 PREDEFINED_MAP = {handshape.canonical: handshape for handshape in PREDEFINED_MAP.values()}
 
-delimiter = ">"  # TODO KV - should this be user-defined in global settings? or maybe even in the module window(s)?
+treepathdelimiter = ">"  # TODO KV - should this be user-defined in global settings? or maybe even in the module window(s)?
 
 
 class ModuleTypes:
@@ -535,7 +535,7 @@ class MovementModule(ParameterModule):
             if selected:
                 # logging.warn(text)
                 # logging.warn(id)
-                pathelements = text.split(delimiter)
+                pathelements = text.split(treepathdelimiter)
                 # thisentrytext = ""
                 # firstonedone = False
                 # morethanone = False

--- a/src/main/python/models/location_models.py
+++ b/src/main/python/models/location_models.py
@@ -13,7 +13,7 @@ from PyQt5.Qt import (
 )
 import logging
 
-from lexicon.module_classes import LocationType, userdefinedroles as udr, delimiter, AddedInfo
+from lexicon.module_classes import LocationType, userdefinedroles as udr, treepathdelimiter, AddedInfo
 from serialization_classes import LocationTreeSerializable, LocationTableSerializable
 from constant import HAND, ARM, LEG
 
@@ -517,12 +517,12 @@ class LocationTreeModel(QStandardItemModel):
         dicts = [self.serializedlocntree.checkstates, self.serializedlocntree.addedinfos, self.serializedlocntree.detailstables]
 
         # As of 20230631, entries with "other hand>whole hand" will be moved to "other hand" with surfaces and subareas preserved
-        if ("Other hand"+delimiter+"Whole hand" in self.serializedlocntree.checkstates):
-            if (self.serializedlocntree.checkstates["Other hand"+delimiter+"Whole hand"] == Qt.Checked):
+        if ("Other hand"+treepathdelimiter+ "Whole hand" in self.serializedlocntree.checkstates):
+            if (self.serializedlocntree.checkstates["Other hand" + treepathdelimiter + "Whole hand"] == Qt.Checked):
                 for stored_dict in dicts:
-                    stored_dict["Whole hand"] = stored_dict["Other hand"+delimiter+"Whole hand"] 
+                    stored_dict["Whole hand"] = stored_dict["Other hand" + treepathdelimiter + "Whole hand"]
             for stored_dict in dicts:
-                stored_dict.pop("Other hand"+delimiter+"Whole hand")
+                stored_dict.pop("Other hand" + treepathdelimiter + "Whole hand")
         # As of 20230918, rename "Other hand" back to "Whole hand"
         if ("Other hand" in self.serializedlocntree.checkstates):
             if (self.serializedlocntree.checkstates["Other hand"] == Qt.Checked):
@@ -716,7 +716,7 @@ class LocationTreeModel(QStandardItemModel):
                         if idx + 1 == numentriesatthislevel:
                             thistreenode.setData(True, role=Qt.UserRole+udr.lastingrouprole)
                             thistreenode.setData(isfinalsubgroup, role=Qt.UserRole+udr.finalsubgrouprole)
-                    self.populate(thistreenode, structure=child, pathsofar=pathsofar + label + delimiter)
+                    self.populate(thistreenode, structure=child, pathsofar=pathsofar + label + treepathdelimiter)
                     parentnode.appendRow([thistreenode])
 
     @property
@@ -794,7 +794,7 @@ class BodypartTreeModel(LocationTreeModel):
         if "Heel of hand" in self.serializedlocntree.checkstates: # check if this is an old version
             for val in hand_children:
                 for stored_dict in dicts:
-                    stored_dict["Whole hand"+delimiter+val] = stored_dict[val] 
+                    stored_dict["Whole hand" + treepathdelimiter + val] = stored_dict[val]
                     stored_dict.pop(val)
 
 

--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (
     QMessageBox
 )
 
-from lexicon.module_classes import userdefinedroles as udr, delimiter, AddedInfo
+from lexicon.module_classes import userdefinedroles as udr, treepathdelimiter, AddedInfo
 
 # for backwards compatibility
 specifytotalcycles_str = "Specify total number of cycles"
@@ -1232,23 +1232,23 @@ class MovementTreeModel(QStandardItemModel):
         dicts = self.serializedmvmttree.checkstates, self.serializedmvmttree.addedinfos  # self.numvals, self.stringvals,
 
         # 20230707: "trill" is now suboption of "repetition"; previously they were at the same level
-        old_trill_path = "Movement characteristics"+delimiter+"Trill"
+        old_trill_path = "Movement characteristics" + treepathdelimiter + "Trill"
         stored_dict = self.serializedmvmttree.checkstates
         if (old_trill_path in stored_dict):
             # If old Trill / Trilled was selected, the new Trilled is selected and anything for single/repeated is gone.
-            if (stored_dict[old_trill_path+delimiter+"Trilled"] == Qt.Checked):
-                stored_dict["Movement characteristics"+delimiter+"Repetition"] = Qt.Unchecked
-                stored_dict["Movement characteristics"+delimiter+"Repetition"+delimiter+"Trilled"] = Qt.Checked
-                if old_trill_path+delimiter+"Trilled" in self.serializedmvmttree.addedinfos:
-                    self.serializedmvmttree.addedinfos["Movement characteristics"+delimiter+"Repetition"+delimiter+"Trilled"] = self.serializedmvmttree.addedinfos[old_trill_path+delimiter+"Trilled"]
-                    self.serializedmvmttree.addedinfos.pop(old_trill_path + delimiter + "Trilled")
-                stored_dict.pop(old_trill_path + delimiter + "Trilled")
+            if (stored_dict[old_trill_path + treepathdelimiter + "Trilled"] == Qt.Checked):
+                stored_dict["Movement characteristics" + treepathdelimiter + "Repetition"] = Qt.Unchecked
+                stored_dict["Movement characteristics" + treepathdelimiter + "Repetition" + treepathdelimiter + "Trilled"] = Qt.Checked
+                if old_trill_path+treepathdelimiter+ "Trilled" in self.serializedmvmttree.addedinfos:
+                    self.serializedmvmttree.addedinfos["Movement characteristics" + treepathdelimiter + "Repetition" + treepathdelimiter + "Trilled"] = self.serializedmvmttree.addedinfos[old_trill_path + treepathdelimiter + "Trilled"]
+                    self.serializedmvmttree.addedinfos.pop(old_trill_path + treepathdelimiter + "Trilled")
+                stored_dict.pop(old_trill_path + treepathdelimiter + "Trilled")
             # If old Trill / Not trilled was selected, the new Trilled is not selected and anything for single/repeated stays.
-            elif (stored_dict[old_trill_path+delimiter+"Not trilled"] == Qt.Checked):
-                stored_dict["Movement characteristics"+delimiter+"Repetition"+delimiter+"Trilled"] = Qt.Unchecked
-                if old_trill_path+delimiter+"Not trilled" in self.serializedmvmttree.addedinfos:
-                    self.serializedmvmttree.addedinfos.pop(old_trill_path + delimiter + "Not trilled")
-                stored_dict.pop(old_trill_path + delimiter + "Not trilled")
+            elif (stored_dict[old_trill_path + treepathdelimiter + "Not trilled"] == Qt.Checked):
+                stored_dict["Movement characteristics" + treepathdelimiter + "Repetition" + treepathdelimiter + "Trilled"] = Qt.Unchecked
+                if old_trill_path+treepathdelimiter+ "Not trilled" in self.serializedmvmttree.addedinfos:
+                    self.serializedmvmttree.addedinfos.pop(old_trill_path + treepathdelimiter + "Not trilled")
+                stored_dict.pop(old_trill_path + treepathdelimiter + "Not trilled")
             stored_dict.pop(old_trill_path)
 
 
@@ -1284,20 +1284,20 @@ class MovementTreeModel(QStandardItemModel):
                         keystoremove.append(k)
 
                     elif "This number is a minimum" in k:
-                        pairstoadd[k.replace(delimiter + "#" + delimiter, delimiter)] = stored_dict[k]
+                        pairstoadd[k.replace(treepathdelimiter + "#" + treepathdelimiter, treepathdelimiter)] = stored_dict[k]
                         keystoremove.append(k)
 
-                    elif (specifytotalcycles_str + delimiter in k or numberofreps_str + delimiter in k):
+                    elif (specifytotalcycles_str + treepathdelimiter in k or numberofreps_str + treepathdelimiter in k):
                         # then we're looking at the item that stores info about the specified number of repetitions
                         newkey = k.replace(numberofreps_str, specifytotalcycles_str)
-                        newkey = newkey[:newkey.index(specifytotalcycles_str+delimiter) + len(specifytotalcycles_str)]
+                        newkey = newkey[:newkey.index(specifytotalcycles_str + treepathdelimiter) + len(specifytotalcycles_str)]
                         remainingtext = ""
                         if specifytotalcycles_str in k:
-                            remainingtext = k[k.index(specifytotalcycles_str + delimiter) + len(specifytotalcycles_str + delimiter):]
+                            remainingtext = k[k.index(specifytotalcycles_str + treepathdelimiter) + len(specifytotalcycles_str + treepathdelimiter):]
                         elif numberofreps_str in k:
-                            remainingtext = k[k.index(specifytotalcycles_str + delimiter) + len(numberofreps_str + delimiter):]
+                            remainingtext = k[k.index(specifytotalcycles_str + treepathdelimiter) + len(numberofreps_str + treepathdelimiter):]
 
-                        if len(remainingtext) > 0 and delimiter not in remainingtext and remainingtext != "#":
+                        if len(remainingtext) > 0 and treepathdelimiter not in remainingtext and remainingtext != "#":
                             numcycles = remainingtext
                             userspecifiedvalues[newkey] = numcycles
 
@@ -1553,7 +1553,7 @@ class MovementTreeModel(QStandardItemModel):
                         if idx + 1 == numentriesatthislevel:
                             thistreenode.setData(True, role=Qt.UserRole + udr.lastingrouprole)
                             thistreenode.setData(isfinalsubgroup, role=Qt.UserRole + udr.finalsubgrouprole)
-                    self.populate(thistreenode, structure=child, pathsofar=pathsofar+label+delimiter, idsequence=idsequence)
+                    self.populate(thistreenode, structure=child, pathsofar=pathsofar + label + treepathdelimiter, idsequence=idsequence)
                     # self.populate(thistreenode, structure=child, pathsofar=pathsofar+label+delimiter, idsequence=idsequence.append(node_id))
                     parentnode.appendRow([thistreenode, editablepart])
 


### PR DESCRIPTION
also had to change the name of the delimiter used for separating nodes in movement tree paths, for the sake of differentiating from this one