### PR TITLE
331: Add warning before saving "both hands" for 1 handed signs

### DIFF
--- a/src/main/python/constant.py
+++ b/src/main/python/constant.py
@@ -349,6 +349,30 @@ CONTRA = "contra"
 IPSI = "ipsi"
 
 
+# Sign type constants
+SIGN_TYPE = {
+    "ONE_HAND": "1h",
+    "ONE_HAND_MVMT": "1h.moves",
+    "ONE_HAND_NO_MVMT": "1h.no mvmt",
+    "TWO_HANDS": "2h",
+    "TWO_HANDS_SAME_HCONF": "2h.same HCs",
+    "TWO_HANDS_DIFF_HCONF": "2h.different HCs",
+    "TWO_HANDS_MAINT_CONT": "2h.maintain contact",
+    "TWO_HANDS_NO_CONT": "2h.contact not maintained",
+    "TWO_HANDS_BISYM": "2h.bilaterally symmetric",
+    "TWO_HANDS_NO_BISYM": "2h.not bilaterally symmetric",
+    "TWO_HANDS_NO_MVMT": "2h.neither moves",
+    "TWO_HANDS_ONE_MVMT": "2h.only 1 moves",
+    "TWO_HANDS_BOTH_MVMT": "2h.both move",
+    "TWO_HANDS_ONLY_H1": "2h.only 1 moves.H1 moves",
+    "TWO_HANDS_ONLY_H2": "2h.only 1 moves.H2 moves",
+    "TWO_HANDS_BOTH_MVMT_DIFF": "2h.both move.move differently",
+    "TWO_HANDS_BOTH_MVMT_SAME": "2h.both move.move similarly",
+    "TWO_HANDS_BOTH_MVMT_SEQ": "2h.both move.move similarly.sequential",
+    "TWO_HANDS_BOTH_MVMT_SIMU": "2h.both move.move similarly.simultaneous"
+}
+
+
 treepathdelimiter = ">" # define here or in module_classes?
 DEFAULT_LOC_1H = {"Horizontal axis" + treepathdelimiter + "Ipsi": None, 
                 "Vertical axis" + treepathdelimiter + "Mid": None,

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -69,13 +69,14 @@ class ModuleSelectorDialog(QDialog):
         if HAND in incl_articulators and self.parent().sign.signtype:
             # set default articulators
             self.signtype_specslist = { art_setting[0] for art_setting in self.parent().sign.signtype.specslist } 
-            if SIGN_TYPE["ONE_HAND"] in self.signtype_specslist and SIGN_TYPE["ONE_HAND_NO_MVMT"] not in self.signtype_specslist:
+            if SIGN_TYPE["ONE_HAND"] in self.signtype_specslist and \
+                not (SIGN_TYPE["ONE_HAND_NO_MVMT"] in self.signtype_specslist and self.moduletype == ModuleTypes.MOVEMENT):
                 articulators = (HAND, {1: True, 2: False})
             elif self.moduletype == ModuleTypes.MOVEMENT:
                 if SIGN_TYPE["TWO_HANDS_ONLY_H1"] in self.signtype_specslist:
                     articulators = (HAND, {1: True, 2: False})
                 elif SIGN_TYPE["TWO_HANDS_ONLY_H2"] in self.signtype_specslist:
-                    articulators = (HAND, {1: False, 2: True})            
+                    articulators = (HAND, {1: False, 2: True})        
         if moduletoload is not None:
             self.existingkey = moduletoload.uniqueid
             timingintervals = deepcopy(moduletoload.timingintervals)

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -70,13 +70,13 @@ class ModuleSelectorDialog(QDialog):
             # set default articulators
             self.signtype_specslist = { art_setting[0] for art_setting in self.parent().sign.signtype.specslist } 
             if SIGN_TYPE["ONE_HAND"] in self.signtype_specslist and \
-                not (SIGN_TYPE["ONE_HAND_NO_MVMT"] in self.signtype_specslist and self.moduletype == ModuleTypes.MOVEMENT):
+             (SIGN_TYPE["ONE_HAND_NO_MVMT"] not in self.signtype_specslist or self.moduletype != ModuleTypes.MOVEMENT):
                 articulators = (HAND, {1: True, 2: False})
             elif self.moduletype == ModuleTypes.MOVEMENT:
                 if SIGN_TYPE["TWO_HANDS_ONLY_H1"] in self.signtype_specslist:
                     articulators = (HAND, {1: True, 2: False})
                 elif SIGN_TYPE["TWO_HANDS_ONLY_H2"] in self.signtype_specslist:
-                    articulators = (HAND, {1: False, 2: True})        
+                    articulators = (HAND, {1: False, 2: True})
         if moduletoload is not None:
             self.existingkey = moduletoload.uniqueid
             timingintervals = deepcopy(moduletoload.timingintervals)

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -273,11 +273,12 @@ class ModuleSelectorDialog(QDialog):
             elif SIGN_TYPE["TWO_HANDS"] in self.signtype_specslist and self.moduletype == ModuleTypes.MOVEMENT:
                 if SIGN_TYPE["TWO_HANDS_NO_MVMT"] in self.signtype_specslist and (articulator_dict[1] or articulator_dict[2]):
                     warning_msg = "The sign type for this sign specifies that neither hand moves. Are you sure you want this movement module to exist?"
-                elif SIGN_TYPE["TWO_HANDS_ONLY_H1"] in self.signtype_specslist and (articulator_dict[2] or (articulator[1] and articulator[2])):
+                elif SIGN_TYPE["TWO_HANDS_ONLY_H2"] in self.signtype_specslist and (articulator_dict[2] or (articulator[1] and articulator[2])):
                     warning_msg= "The sign type for this sign specifies that only H1 moves. Are you sure you want this movement module to exist?"
-                elif SIGN_TYPE["TWO_HANDS_ONLY_H1"] in self.signtype_specslist and (articulator_dict[1] or (articulator[1] and articulator[2])) \
-                    or SIGN_TYPE["TWO_HANDS_ONE_MVMT"] in self.signtype_specslist and (articulator[1] and articulator[2]):
+                elif SIGN_TYPE["TWO_HANDS_ONLY_H1"] in self.signtype_specslist and (articulator_dict[1] or (articulator[1] and articulator[2])):
                     warning_msg= "The sign type for this sign specifies that only H2 moves. Are you sure you want this movement module to exist?"
+                elif SIGN_TYPE["TWO_HANDS_ONE_MVMT"] in self.signtype_specslist and (articulator[1] and articulator[2]):
+                    warning_msg="The sign type for this sign specifies that only one hand moves. Are you sure you want this movement module to exist?"
         return articulatorsvalid, (articulator, articulator_dict), warning_msg
 
     def handle_button_click(self, button):

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -72,9 +72,6 @@ class ModuleSelectorDialog(QDialog):
             if "1h" in handSelection:
                 articulators = (HAND, {1: True, 2: False})
                 self.defaultHandArticulator = "1h"
-            elif "2h" in handSelection:
-                articulators = (HAND, {1: True, 2: True})
-                self.defaultHandArticulator = "2h"
         if moduletoload is not None:
             self.existingkey = moduletoload.uniqueid
             timingintervals = deepcopy(moduletoload.timingintervals)

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -326,7 +326,7 @@ class ModuleSelectorDialog(QDialog):
             msgBox.setWindowTitle("Articulator Setting Conflict")
             msgBox.setText("The sign type for this sign is 1-handed. Are you sure this module should apply to both hands?")
             no_btn = msgBox.addButton("Return to editing", QMessageBox.ButtonRole.NoRole)
-            msgBox.addButton("Continue", QMessageBox.ButtonRole.YesRole)
+            msgBox.addButton("Continue with both hands", QMessageBox.ButtonRole.YesRole)
             msgBox.setIcon(QMessageBox.Icon.Warning)
             msgBox.exec_()
             if msgBox.clickedButton() == no_btn:

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -724,10 +724,9 @@ class ArticulatorSelectionPanel(QFrame):
             self.articulator_group.setExclusive(False) # this is needed to uncheck all radio buttons
             checkedButton.setChecked(False)
             self.articulator_group.setExclusive(True)
-            if checkedButton == self.botharts_radio:
-                for btn in self.botharts_group.buttons():
-                    btn.setChecked(False)
-                    btn.setEnabled(False)
+            for btn in self.botharts_group.buttons():
+                btn.setChecked(False)
+                btn.setEnabled(False)
 
 
     def handle_articulatorgroup_toggled(self, selectedbutton, ischecked):

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -47,7 +47,7 @@ class ModuleSelectorDialog(QDialog):
     module_saved = pyqtSignal(ParameterModule, str)
     module_deleted = pyqtSignal()
 
-    def __init__(self, moduletype, xslotstructure=None, moduletoload=None, linkedfrommoduleid=None, linkedfrommoduletype=None, includephase=0, incl_articulators=HAND, incl_articulator_subopts=0, **kwargs):
+    def __init__(self, moduletype, xslotstructure=None, moduletoload=None, linkedfrommoduleid=None, linkedfrommoduletype=None, incl_articulators=HAND, incl_articulator_subopts=0, **kwargs):
         super().__init__(**kwargs)
         self.mainwindow = self.parent().mainwindow
         self.moduletype = moduletype
@@ -72,6 +72,14 @@ class ModuleSelectorDialog(QDialog):
             phonlocstoload = moduletoload.phonlocs
             if moduletoload.articulators is not None:
                 articulators = moduletoload.articulators
+        elif HAND in incl_articulators:
+            # set default articulators
+            handSelection = self.parent().sign.signtype.specslist[0][0]
+            if "1h" in handSelection:
+                articulators = (HAND, {1: True, 2: False})
+            elif "2h" in handSelection:
+                articulators = (HAND, {1: True, 2: True})
+            
             new_instance = False
             if isinstance(moduletoload, LocationModule) or isinstance(moduletoload, MovementModule):
                 inphase = moduletoload.inphase

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -739,7 +739,6 @@ class SignSummaryPanel(QScrollArea):
         module_selector = ModuleSelectorDialog(moduletype=moduletype,
                                                xslotstructure=self.sign.xslotstructure,
                                                moduletoload=module_to_edit,
-                                               includephase=includephase,
                                                incl_articulators=includearticulators,
                                                incl_articulator_subopts=includephase,
                                                parent=self
@@ -915,7 +914,6 @@ class SignLevelMenuPanel(QScrollArea):
         module_selector = ModuleSelectorDialog(moduletype=moduletype,
                                                xslotstructure=self.mainwindow.current_sign.xslotstructure,
                                                moduletoload=None,
-                                               includephase=includephase,
                                                incl_articulators=includearticulators,
                                                incl_articulator_subopts=includephase,
                                                parent=self)

--- a/src/main/python/gui/signtypespecification_view.py
+++ b/src/main/python/gui/signtypespecification_view.py
@@ -26,6 +26,7 @@ from PyQt5.QtCore import (
 from gui.modulespecification_dialog import AddedInfoPushButton
 from gui.link_help import show_help
 from lexicon.module_classes import Signtype
+from constant import SIGN_TYPE
 
 
 class SigntypeSpecificationPanel(QFrame):
@@ -46,10 +47,10 @@ class SigntypeSpecificationPanel(QFrame):
         self.handstype_unspec_radio.setProperty('abbreviation.include', True)
         self.addedinfobutton = AddedInfoPushButton("Notes")
         self.handstype_1h_radio = SigntypeRadioButton("1 hand", parentbutton=None)
-        self.handstype_1h_radio.setProperty('abbreviation.path', "1h")
+        self.handstype_1h_radio.setProperty('abbreviation.path', SIGN_TYPE["ONE_HAND"])
         self.handstype_1h_radio.setProperty('abbreviation.include', True)
         self.handstype_2h_radio = SigntypeRadioButton("2 hands", parentbutton=None)
-        self.handstype_2h_radio.setProperty('abbreviation.path', "2h")
+        self.handstype_2h_radio.setProperty('abbreviation.path',  SIGN_TYPE["TWO_HANDS"])
         self.handstype_2h_radio.setProperty('abbreviation.include', True)
         self.handstype_group.addButton(self.handstype_unspec_radio)
         self.handstype_group.addButton(self.handstype_1h_radio)
@@ -59,11 +60,11 @@ class SigntypeSpecificationPanel(QFrame):
         # buttons and groups for 1-handed signs
         self.handstype_1h_group = SigntypeButtonGroup(prt=self)
         self.handstype_1hmove_radio = SigntypeRadioButton('The hand moves', parentbutton=self.handstype_1h_radio)
-        self.handstype_1hmove_radio.setProperty('abbreviation.path', "1h.moves")
+        self.handstype_1hmove_radio.setProperty('abbreviation.path', SIGN_TYPE["ONE_HAND_MVMT"])
         self.handstype_1hmove_radio.setProperty('abbreviation.include', True)
         self.handstype_1hnomove_radio = SigntypeRadioButton("The hand doesn\'t move",
                                                             parentbutton=self.handstype_1h_radio)
-        self.handstype_1hnomove_radio.setProperty('abbreviation.path', "1h.no mvmt")
+        self.handstype_1hnomove_radio.setProperty('abbreviation.path', SIGN_TYPE["ONE_HAND_NO_MVMT"])
         self.handstype_1hnomove_radio.setProperty('abbreviation.include', True)
         self.handstype_1h_group.addButton(self.handstype_1hmove_radio)
         self.handstype_1h_group.addButton(self.handstype_1hnomove_radio)
@@ -73,11 +74,11 @@ class SigntypeSpecificationPanel(QFrame):
         self.handstype_handshapereln_group = SigntypeButtonGroup(prt=self)
         self.handstype_2hsameshapes_radio = SigntypeRadioButton("H1 and H2 use same set(s) of hand configurations",
                                                                 parentbutton=self.handstype_2h_radio)
-        self.handstype_2hsameshapes_radio.setProperty('abbreviation.path', "2h.same HCs")
+        self.handstype_2hsameshapes_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_SAME_HCONF"])
         self.handstype_2hsameshapes_radio.setProperty('abbreviation.include', True)
         self.handstype_2hdiffshapes_radio = SigntypeRadioButton("H1 and H2 use different set(s) of hand configurations",
                                                                 parentbutton=self.handstype_2h_radio)
-        self.handstype_2hdiffshapes_radio.setProperty('abbreviation.path', "2h.different HCs")
+        self.handstype_2hdiffshapes_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_DIFF_HCONF"])
         self.handstype_2hdiffshapes_radio.setProperty('abbreviation.include', True)
         # self.handstype_2hdiffshapes_radio.toggled.connect(self.linkhandconfigbuttons)
         self.handstype_handshapereln_group.addButton(self.handstype_2hsameshapes_radio)
@@ -88,11 +89,11 @@ class SigntypeSpecificationPanel(QFrame):
         self.handstype_contactreln_group = SigntypeButtonGroup(prt=self)
         self.handstype_2hcontactyes_radio = SigntypeRadioButton("H1 and H2 maintain contact throughout sign",
                                                                 parentbutton=self.handstype_2h_radio)
-        self.handstype_2hcontactyes_radio.setProperty('abbreviation.path', "2h.maintain contact")
+        self.handstype_2hcontactyes_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_MAINT_CONT"])
         self.handstype_2hcontactyes_radio.setProperty('abbreviation.include', True)
         self.handstype_2hcontactno_radio = SigntypeRadioButton("H1 and H2 do not maintain contact",
                                                                parentbutton=self.handstype_2h_radio)
-        self.handstype_2hcontactno_radio.setProperty('abbreviation.path', "2h.contact not maintained")
+        self.handstype_2hcontactno_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_NO_CONT"])
         self.handstype_2hcontactno_radio.setProperty('abbreviation.include', False)
         self.handstype_contactreln_group.addButton(self.handstype_2hcontactyes_radio)
         self.handstype_contactreln_group.addButton(self.handstype_2hcontactno_radio)
@@ -102,11 +103,11 @@ class SigntypeSpecificationPanel(QFrame):
         self.handstype_symmetryreln_group = SigntypeButtonGroup(prt=self)
         self.handstype_2hsymmetryyes_radio = SigntypeRadioButton("H1 and H2 are bilaterally symmetric",
                                                                  parentbutton=self.handstype_2h_radio)
-        self.handstype_2hsymmetryyes_radio.setProperty('abbreviation.path', "2h.bilaterally symmetric")
+        self.handstype_2hsymmetryyes_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_BISYM"])
         self.handstype_2hsymmetryyes_radio.setProperty('abbreviation.include', True)
         self.handstype_2hsymmetryno_radio = SigntypeRadioButton("H1 and H2 are not bilaterally symmetric",
                                                                 parentbutton=self.handstype_2h_radio)
-        self.handstype_2hsymmetryno_radio.setProperty('abbreviation.path', "2h.not bilaterally symmetric")
+        self.handstype_2hsymmetryno_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_NO_BISYM"])
         self.handstype_2hsymmetryno_radio.setProperty('abbreviation.include', False)
         self.handstype_symmetryreln_group.addButton(self.handstype_2hsymmetryyes_radio)
         self.handstype_symmetryreln_group.addButton(self.handstype_2hsymmetryno_radio)
@@ -116,13 +117,13 @@ class SigntypeSpecificationPanel(QFrame):
         self.handstype_mvmtreln_group = SigntypeButtonGroup(prt=self)
         self.handstype_2hmvmtneither_radio = SigntypeRadioButton("Neither hand moves",
                                                                  parentbutton=self.handstype_2h_radio)
-        self.handstype_2hmvmtneither_radio.setProperty('abbreviation.path', "2h.neither moves")
+        self.handstype_2hmvmtneither_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_NO_MVMT"])
         self.handstype_2hmvmtneither_radio.setProperty('abbreviation.include', True)
         self.handstype_2hmvmtone_radio = SigntypeRadioButton("Only 1 hand moves", parentbutton=self.handstype_2h_radio)
-        self.handstype_2hmvmtone_radio.setProperty('abbreviation.path', "2h.only 1 moves")
+        self.handstype_2hmvmtone_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_ONE_MVMT"])
         self.handstype_2hmvmtone_radio.setProperty('abbreviation.include', False)
         self.handstype_2hmvmtboth_radio = SigntypeRadioButton("Both hands move", parentbutton=self.handstype_2h_radio)
-        self.handstype_2hmvmtboth_radio.setProperty('abbreviation.path', "2h.both move")
+        self.handstype_2hmvmtboth_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_BOTH_MVMT"])
         self.handstype_2hmvmtboth_radio.setProperty('abbreviation.include', False)
         self.handstype_mvmtreln_group.addButton(self.handstype_2hmvmtneither_radio)
         self.handstype_mvmtreln_group.addButton(self.handstype_2hmvmtone_radio)
@@ -133,11 +134,11 @@ class SigntypeSpecificationPanel(QFrame):
         self.handstype_mvmtonehandreln_group = SigntypeButtonGroup(prt=self)
         self.handstype_2hmvmtoneH1_radio = SigntypeRadioButton("Only H1 moves",
                                                                parentbutton=self.handstype_2hmvmtone_radio)
-        self.handstype_2hmvmtoneH1_radio.setProperty('abbreviation.path', "2h.only 1 moves.H1 moves")
+        self.handstype_2hmvmtoneH1_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_ONLY_H1"])
         self.handstype_2hmvmtoneH1_radio.setProperty('abbreviation.include', True)
         self.handstype_2hmvmtoneH2_radio = SigntypeRadioButton("Only H2 moves",
                                                                parentbutton=self.handstype_2hmvmtone_radio)
-        self.handstype_2hmvmtoneH2_radio.setProperty('abbreviation.path', "2h.only 1 moves.H2 moves")
+        self.handstype_2hmvmtoneH2_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_ONLY_H2"])
         self.handstype_2hmvmtoneH2_radio.setProperty('abbreviation.include', True)
         self.handstype_mvmtonehandreln_group.addButton(self.handstype_2hmvmtoneH1_radio)
         self.handstype_mvmtonehandreln_group.addButton(self.handstype_2hmvmtoneH2_radio)
@@ -147,11 +148,11 @@ class SigntypeSpecificationPanel(QFrame):
         self.handstype_mvmtbothhandreln_group = SigntypeButtonGroup(prt=self)
         self.handstype_2hmvmtbothdiff_radio = SigntypeRadioButton("H1 and H2 move differently",
                                                                   parentbutton=self.handstype_2hmvmtboth_radio)
-        self.handstype_2hmvmtbothdiff_radio.setProperty('abbreviation.path', "2h.both move.move differently")
+        self.handstype_2hmvmtbothdiff_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_BOTH_MVMT_DIFF"])
         self.handstype_2hmvmtbothdiff_radio.setProperty('abbreviation.include', True)
         self.handstype_2hmvmtbothsame_radio = SigntypeRadioButton("H1 and H2 move similarly",
                                                                   parentbutton=self.handstype_2hmvmtboth_radio)
-        self.handstype_2hmvmtbothsame_radio.setProperty('abbreviation.path', "2h.both move.move similarly")
+        self.handstype_2hmvmtbothsame_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_BOTH_MVMT_SAME"])
         self.handstype_2hmvmtbothsame_radio.setProperty('abbreviation.include', True)
         self.handstype_mvmtbothhandreln_group.addButton(self.handstype_2hmvmtbothdiff_radio)
         self.handstype_mvmtbothhandreln_group.addButton(self.handstype_2hmvmtbothsame_radio)
@@ -161,11 +162,11 @@ class SigntypeSpecificationPanel(QFrame):
         self.handstype_mvmttimingreln_group = SigntypeButtonGroup(prt=self)
         self.handstype_2hmvmtseq_radio = SigntypeRadioButton("Sequential",
                                                              parentbutton=self.handstype_2hmvmtbothsame_radio)
-        self.handstype_2hmvmtseq_radio.setProperty('abbreviation.path', "2h.both move.move similarly.sequential")
+        self.handstype_2hmvmtseq_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_BOTH_MVMT_SEQ"])
         self.handstype_2hmvmtseq_radio.setProperty('abbreviation.include', True)
         self.handstype_2hmvmtsimult_radio = SigntypeRadioButton("Simultaneous",
                                                                 parentbutton=self.handstype_2hmvmtbothsame_radio)
-        self.handstype_2hmvmtsimult_radio.setProperty('abbreviation.path', "2h.both move.move similarly.simultaneous")
+        self.handstype_2hmvmtsimult_radio.setProperty('abbreviation.path', SIGN_TYPE["TWO_HANDS_BOTH_MVMT_SIMU"] )
         self.handstype_2hmvmtsimult_radio.setProperty('abbreviation.include', True)
         self.handstype_mvmttimingreln_group.addButton(self.handstype_2hmvmtseq_radio)
         self.handstype_mvmttimingreln_group.addButton(self.handstype_2hmvmtsimult_radio)


### PR DESCRIPTION
- Added warning dialog when we encounter scenario described in title
- deleted `includephrase` reference -- doesn't seem like it is being used?

https://github.com/user-attachments/assets/89081e14-12a1-4f3e-abf3-ff0c1ad314ab

https://github.com/user-attachments/assets/ece2d6f7-d871-4771-9c82-17059d15d96c


Note: If you toggle between the options it will reset

https://github.com/user-attachments/assets/1714b2f0-f5f1-481e-bb19-6d56eaa83c65

