### PR TITLE
fix issue #372

### DIFF
--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -56,7 +56,7 @@ class ModuleSelectorDialog(QDialog):
         self.linkedfrommoduletype = linkedfrommoduletype
         self.existingkey = None
 
-        timingintervals = []
+        self.loaded_timingintervals = []
         addedinfo = AddedInfo()
         phonlocstoload = None
         new_instance = True
@@ -67,7 +67,7 @@ class ModuleSelectorDialog(QDialog):
 
         if moduletoload is not None:
             self.existingkey = moduletoload.uniqueid
-            timingintervals = deepcopy(moduletoload.timingintervals)
+            self.loaded_timingintervals = deepcopy(moduletoload.timingintervals)
             addedinfo = deepcopy(moduletoload.addedinfo)
             phonlocstoload = moduletoload.phonlocs
             if moduletoload.articulators is not None:
@@ -106,7 +106,7 @@ class ModuleSelectorDialog(QDialog):
         if self.mainwindow.app_settings['signdefaults']['xslot_generation'] != 'none':
             self.usexslots = True
             self.xslot_widget = XslotLinkingPanel(xslotstructure=xslotstructure,
-                                                  timingintervals=timingintervals,
+                                                  timingintervals=self.loaded_timingintervals,
                                                   parent=self)
             main_layout.addWidget(self.xslot_widget)
 
@@ -237,9 +237,15 @@ class ModuleSelectorDialog(QDialog):
         if self.usexslots:
             timingintervals = self.xslot_widget.gettimingintervals()
             timingvalid = len(timingintervals) != 0
+        elif len(self.loaded_timingintervals) > 0:
+            # we're currently in "no x-slots" mode BUT we've loaded a previously-existing module that was
+            #   created when x-slots *were* being used... so preserve the existing timing information in
+            #   case the user wants to return to x-slots mode
+            timingintervals = self.loaded_timingintervals
+            timingvalid = True
         else:
             # no x-slots; make the timing interval be for the whole sign
-            timingintervals = [TimingInterval(TimingPoint(0, 0), TimingPoint(1, 0))]
+            timingintervals = [TimingInterval(TimingPoint(0, 0), TimingPoint(0, 1))]
             timingvalid = True
 
         return timingvalid, timingintervals
@@ -331,7 +337,7 @@ class ModuleSelectorDialog(QDialog):
         if messagestring != "":
             # warn user that there's missing and/or invalid info and don't let them save
             QMessageBox.critical(self, "Warning", messagestring)
-        elif messagestring == "" and modulevalid == False:
+        elif messagestring == "" and not modulevalid:
             return savedmodule 
         elif addanother:
             # save info and then refresh screen to start next module

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -812,6 +812,8 @@ class TimingPoint:
 
 # TODO KV comments
 # TODO KV - for parameter modules and x-slots
+# in order to represent a "whole sign" timing interval (no matter how many x-slots long), use
+#   TimingInterval(TimingPoint(0, 0), TimingPoint(0, 1))
 class TimingInterval:
 
     # startpt (type TimingPoint) = the point at which this xslot interval begins


### PR DESCRIPTION
ensure that if there is existing x-slot information (even if x-slots are currently turned off), that the existing info is preserved in case the user wants to return to x-slots mode