### PR TITLE
191 provide copy module and copy sign options

### DIFF
--- a/src/main/python/constant.py
+++ b/src/main/python/constant.py
@@ -391,6 +391,9 @@ class ModuleTypes:
         NONMANUAL: 'NonMan'
     }
 
+    parametertypes = list(abbreviations.keys())
+    parametertypes_relationfirst = [RELATION] + [mtype for mtype in parametertypes if mtype != 'relation']
+
 
 class UserDefinedRoles(dict):
     __getattr__ = dict.__getitem__

--- a/src/main/python/constant.py
+++ b/src/main/python/constant.py
@@ -373,7 +373,90 @@ SIGN_TYPE = {
 }
 
 
-treepathdelimiter = ">" # define here or in module_classes?
+class ModuleTypes:
+    MOVEMENT = 'movement'
+    LOCATION = 'location'
+    HANDCONFIG = 'handconfig'
+    RELATION = 'relation'
+    ORIENTATION = 'orientation'
+    NONMANUAL = 'nonmanual'
+    SIGNTYPE = 'signtype'
+
+    abbreviations = {
+        MOVEMENT: 'Mov',
+        LOCATION: 'Loc',
+        HANDCONFIG: 'Config',
+        RELATION: 'Rel',
+        ORIENTATION: 'Ori',
+        NONMANUAL: 'NonMan'
+    }
+
+
+
+class UserDefinedRoles(dict):
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
+userdefinedroles = UserDefinedRoles({
+    'selectedrole': 0,
+        # selectedrole:
+        # Used by MovementTreeItem, LocationTreeItem, MovementListItem, LocationListItem to indicate
+        # whether they are selected by the user. Not exactly the same as ...Item.checkState() because:
+        #   (1) selectedrole only uses True & False whereas checkstate has none/partial/full, and
+        #   (2) ListItems don't actually get checked, but we still need to track whether they've been selected
+    'pathdisplayrole': 1,
+        # pathdisplayrole:
+        # Used by LocationTreeModel, LocationListModel, LocationPathsProxyModel (and similar for Movement) to access
+        # the full path (node names, separated by delimiters) of the model Item in question,
+        # generally for purposes of displaying in the selectd paths list in the Location or Movement dialog
+    'mutuallyexclusiverole': 2,
+        # mutuallyexclusiverole:
+        # Used by MovementTreeItem & LocationTreeItem to identify the item's relationship to its siblings,
+        # which also involves its display as a radio button vs a checkbox.
+    # 'unusedrole': 3,
+        # unusedrole:
+        # currently unused; can repurpose if needed
+    'lastingrouprole': 4,
+        # lastingrouprole:
+        # used by MovementTreeItemDelegate to determine whether the relevant model Item is the last
+        # in its subgroup, which affects how it is painted in the movement tree
+        # (eg, whether the item will be followed by a horizontal line)
+    'finalsubgrouprole': 5,
+        # finalsubgrouprole:
+        # Used by MovementTreeItem & LocationTreeItem to identify whether an item that is in a subgroup is
+        # also in the *last* subgroup in its section. Such a subgroup will not have a horizontal line drawn after it.
+    'subgroupnamerole': 6,
+        # subgroupnamerole:
+        # Used by MovementTreeItem & LocationTreeItem to identify which items are grouped together. Such
+        # subgroups are separated from other siblings by a horizontal line in the tree, and item selection
+        # is often (always?) mutually exclusive within the subgroup.
+    'nodedisplayrole': 7,
+        # nodedisplayrole:
+        # Used by MovementListItem & LocationListItem to store just the corresponding treeitem's node name
+        # (not the entire path), currently only for sorting listitems by alpha (by lowest node).
+    'timestamprole': 8,
+        # timestamprole:
+        # Used by LocationPathsProxyModel and MovementPathsProxyModel as one option on which to sort selected paths
+    'isuserspecifiablerole': 9,
+        # isuserspecifiablerole:
+        # Used by MovementTreeItem to indicate that this tree item allows the user to specify a particular value.
+        # If 0, the corresponding QStandardItem (ie, the "editable part") is marked not editable; the user cannot change its value;
+        # If 1, the corresponding QStandardItem is marked editable but must be a number, >= 1, and a multiple of 0.5;
+        # If 2, the corrresponding QStandardItem is marked editable but must be a number;
+        # If 3, the corrresponding QStandardItem is marked editable with no restrictions.
+        # This kind of editable functionality was formerly achieved via a separate (subsidiary) editable MovementTreeItem.
+    'userspecifiedvaluerole': 10,
+        # userspecifiedvaluerole:
+        # Used by MovementTreeItem to store the (string) value for an item that is allowed to be user-specified.
+})
+
+
+# TODO KV - define here or in module_classes? or user-defined in global settings? or maybe even in the module window(s)?
+treepathdelimiter = ">"
+
+
 DEFAULT_LOC_1H = {"Horizontal axis" + treepathdelimiter + "Ipsi": None, 
                 "Vertical axis" + treepathdelimiter + "Mid": None,
                 "Sagittal axis" + treepathdelimiter + "In front" + treepathdelimiter + "Med.": None}

--- a/src/main/python/constant.py
+++ b/src/main/python/constant.py
@@ -392,7 +392,6 @@ class ModuleTypes:
     }
 
 
-
 class UserDefinedRoles(dict):
     __getattr__ = dict.__getitem__
     __setattr__ = dict.__setitem__
@@ -415,18 +414,19 @@ userdefinedroles = UserDefinedRoles({
         # mutuallyexclusiverole:
         # Used by MovementTreeItem & LocationTreeItem to identify the item's relationship to its siblings,
         # which also involves its display as a radio button vs a checkbox.
-    # 'unusedrole': 3,
-        # unusedrole:
-        # currently unused; can repurpose if needed
-    'lastingrouprole': 4,
-        # lastingrouprole:
-        # used by MovementTreeItemDelegate to determine whether the relevant model Item is the last
+    'nocontrolrole': 3,
+        # nocontrolrole:
+        # used by MovementTreeItemDelegate when a MovementTreeItem is never a selectable item
+        # so text may be displayed, but no checkbox or radiobutton
+    'firstingrouprole': 4,
+        # firstingrouprole:
+        # used by MovementTreeItemDelegate to determine whether the relevant model Item is the first
         # in its subgroup, which affects how it is painted in the movement tree
-        # (eg, whether the item will be followed by a horizontal line)
-    'finalsubgrouprole': 5,
-        # finalsubgrouprole:
+        # (eg, whether the item will be preceded by a horizontal line)
+    'firstsubgrouprole': 5,
+        # firstsubgrouprole:
         # Used by MovementTreeItem & LocationTreeItem to identify whether an item that is in a subgroup is
-        # also in the *last* subgroup in its section. Such a subgroup will not have a horizontal line drawn after it.
+        # also in the *first* subgroup in its section. Such a subgroup will not have a horizontal line drawn before it.
     'subgroupnamerole': 6,
         # subgroupnamerole:
         # Used by MovementTreeItem & LocationTreeItem to identify which items are grouped together. Such
@@ -450,6 +450,7 @@ userdefinedroles = UserDefinedRoles({
     'userspecifiedvaluerole': 10,
         # userspecifiedvaluerole:
         # Used by MovementTreeItem to store the (string) value for an item that is allowed to be user-specified.
+
 })
 
 

--- a/src/main/python/gui/bodypartspecification_dialog.py
+++ b/src/main/python/gui/bodypartspecification_dialog.py
@@ -18,7 +18,7 @@ from PyQt5.QtCore import (
 from gui.modulespecification_widgets import AddedInfoPushButton
 from gui.locationspecification_view import LocationOptionsSelectionPanel
 from models.location_models import BodypartTreeModel
-from lexicon.module_classes import AddedInfo, treepathdelimiter, BodypartInfo
+from lexicon.module_classes import AddedInfo, BodypartInfo
 from constant import HAND, ARM, LEG
 from serialization_classes import LocationTreeSerializable
 import logging

--- a/src/main/python/gui/corpus_view.py
+++ b/src/main/python/gui/corpus_view.py
@@ -14,7 +14,9 @@ from PyQt5.QtWidgets import (
     QComboBox,
     QAbstractItemView,
     QRadioButton,
-    QButtonGroup
+    QButtonGroup,
+    QMenu,
+    QAction
 )
 
 from PyQt5.QtCore import (
@@ -24,7 +26,6 @@ from PyQt5.QtCore import (
 
 from models.corpus_models import CorpusModel, CorpusSortProxyModel
 from lexicon.lexicon_classes import Sign
-from gui.modulespecification_widgets import SignEntryContextMenu
 
 
 class CorpusDisplay(QWidget):
@@ -235,6 +236,37 @@ class CorpusDisplay(QWidget):
         filteredlines = self.getrowcount()
         totallines = self.corpus_model.rowCount()
         self.numlines_label.setText(str(filteredlines) + " of " + str(totallines) + " glosses shown")
+
+
+# menu associated with a sign entry/entries in the corpus view, offering copy/paste/edit/delete functions
+class SignEntryContextMenu(QMenu):
+    action_selected = pyqtSignal(str)  # "copy", "edit" (sign-level info), or "delete"
+
+    # individual menu items are enabled/disabled based on whether any signs are currently selected
+    #   and/or whether there are any signs on the clipboard
+    def __init__(self, has_selectedsigns, has_clipboardsigns):
+        super().__init__()
+
+        self.copy_action = QAction("Copy Sign(s)")
+        self.copy_action.setEnabled(has_selectedsigns)
+        self.copy_action.triggered.connect(lambda checked: self.action_selected.emit("copy"))
+        self.addAction(self.copy_action)
+
+        self.paste_action = QAction("Paste Sign(s)")
+        self.paste_action.setEnabled(has_clipboardsigns)
+        self.paste_action.triggered.connect(lambda checked: self.action_selected.emit("paste"))
+        self.addAction(self.paste_action)
+
+        self.edit_action = QAction("Edit Sign-level Info(s)")
+        self.edit_action.setEnabled(has_selectedsigns)
+        self.edit_action.triggered.connect(lambda checked: self.action_selected.emit("edit"))
+        self.addAction(self.edit_action)
+
+        self.delete_action = QAction("Delete Sign(s)")
+        self.delete_action.setEnabled(has_selectedsigns)
+        self.delete_action.triggered.connect(lambda checked: self.action_selected.emit("delete"))
+        self.addAction(self.delete_action)
+
 
 class CorpusTableView(QTableView):
     newcurrentindex = pyqtSignal(QModelIndex)

--- a/src/main/python/gui/decorator.py
+++ b/src/main/python/gui/decorator.py
@@ -1,6 +1,5 @@
 import os
 import functools
-from datetime import date
 
 from PyQt5.QtWidgets import (
     QMessageBox,

--- a/src/main/python/gui/link_help.py
+++ b/src/main/python/gui/link_help.py
@@ -7,19 +7,19 @@ from os import getcwd, path
 from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtGui import QIcon  # for version number message box icon
 
-from constant import FROZEN, VERSION
+from constant import FROZEN, VERSION, ModuleTypes
 
 help_map = {
     # help_map is a dictionary of functionality (key) and the corresponding help page (value)
-    'movement': 'movement_module',
-    'location': 'location_module',
-    'handconfig': 'hand_configuration_module',   # coming from the 'Help' btn in the hand configuration dialog
+    ModuleTypes.MOVEMENT: 'movement_module',
+    ModuleTypes.LOCATION: 'location_module',
+    ModuleTypes.HANDCONFIG: 'hand_configuration_module',   # coming from the 'Help' btn in the hand configuration dialog
     'predefined_handshapes': 'predefined_handshapes',  # coming from the btn below 'load predefined handshape' inside hc
-    'relation': 'relation_module',
-    'orientation': 'orientation_module',
-    'nonmanual': 'nonmanual_module',
+    ModuleTypes.RELATION: 'relation_module',
+    ModuleTypes.ORIENTATION: 'orientation_module',
+    ModuleTypes.NONMANUAL: 'nonmanual_module',
     'signlevel': 'sign_level_info',
-    'signtype': 'sign_type',
+    ModuleTypes.SIGNTYPE: 'sign_type',
     'xslot': 'timing',  # for sign timing and xslots
     'preferences': 'global_settings',  # coming from preferences dialog
 }

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1063,8 +1063,9 @@ class MainWindow(QMainWindow):
             else:
                 # otherwise paste, once we've confirmed that the user is ok with overwriting
                 signtype_q = "You are about to overwrite the existing sign type for this sign."
-                signtype_q += "\n\nNote also that you must check for sign type compatibility (e.g. one-handed sign type vs "
-                signtype_q += "two-handed modules) yourself; SLP-AA has not done it for you."
+                signtype_q += "\n\nNote also that you must check for compatibility between modules "
+                signtype_q += "(e.g. one-handed sign type vs two-handed modules) yourself; "
+                signtype_q += "SLP-AA has not done it for you."
                 signtype_q += "\n\nDo you still want to paste the copied sign type into this sign?"
                 response = QMessageBox.question(self, "Overwrite sign type", signtype_q,
                                                 QMessageBox.Yes | QMessageBox.No)

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1079,11 +1079,8 @@ class MainWindow(QMainWindow):
 
         # confirm that the user is ok with timing being reset to whole sign, in case of x-slot structure mismatch
         mismatchedxslots_q = "The x-slot structures of the source and destination signs do not match."
-        mismatchedxslots_q += " If you proceed, you should manually check the timing options in the pasted module(s)."
-        # TODO KV remove once wording is confirmed
-        # "Each pasted module will have its timing reset to the whole sign; "
-        # mismatchedxslots_q += "you will need to open the pasted modules and re-specify timing for each."
-        # "The module to be pasted has a different number of x-slots than the current sign. If you proceed, you should manually check the timing options in the pasted module."
+        mismatchedxslots_q += " If you proceed, each pasted module will have have its timing reset to the whole sign; "
+        mismatchedxslots_q += "you should manually check the timing options in the pasted module(s)."
         reset_xslots = False
 
         if len(parametermodules) > 0 and self.app_settings['signdefaults']['xslot_generation'] != 'none':

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1058,7 +1058,7 @@ class MainWindow(QMainWindow):
         signtypemodules = [mod for mod in listfromclipboard if isinstance(mod, Signtype)]
         for signtypemod in signtypemodules:
             # if it's the same one as the sign we're already in (ie trying to copy/paste in same sign), do nothing
-            if self.current_sign.signtype == signtypemod:
+            if self.current_sign.signtype == signtypemod or self.current_sign.signtype is None:
                 pass
             else:
                 # otherwise paste, once we've confirmed that the user is ok with overwriting
@@ -1081,8 +1081,8 @@ class MainWindow(QMainWindow):
         mismatchedxslots_q += " If you proceed, you should manually check the timing options in the pasted module(s)."  # "Each pasted module will have its timing reset to the whole sign; "
         reset_xslots = False
 
-        if len(parametermodules) > 0:
-            # check x-slot structure of source vs destination signs
+        if len(parametermodules) > 0 and self.app_settings['signdefaults']['xslot_generation'] != 'none':
+            # check x-slot structure of source vs destination signs, assuming that x-slot structure is relevant at all
             xslots_src = self.copypaste_referencesign.xslotstructure
             xslots_dest = self.current_sign.xslotstructure
             if xslots_src != xslots_dest:

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -67,7 +67,7 @@ from lexicon.module_classes import ParameterModule
 from lexicon.lexicon_classes import Corpus, Sign, glossesdelimiter
 from serialization_classes import renamed_load
 from constant import ModuleTypes
-from lexicon.module_utils import deepcopymodule
+from lexicon.module_utils import deepcopymodule, deepcopysign
 
 
 class SubWindow(QMdiSubWindow):
@@ -1062,10 +1062,10 @@ class MainWindow(QMainWindow):
                 pass
             else:
                 # otherwise paste, once we've confirmed that the user is ok with overwriting
-                question1 = "You are about to overwrite the existing sign type for this sign. "
-                question1 += "Note also that you must check for sign type compatibility (e.g. one-handed sign type vs "
-                question1 += "two-handed modules) yourself; SLP-AA has not done it for you. "
-                question1 += "Do you still want to paste the copied sign type into this sign?"
+                question1 = "You are about to overwrite the existing sign type for this sign."
+                question1 += "\n\nNote also that you must check for sign type compatibility (e.g. one-handed sign type vs "
+                question1 += "two-handed modules) yourself; SLP-AA has not done it for you."
+                question1 += "\n\nDo you still want to paste the copied sign type into this sign?"
                 response = QMessageBox.question(self, "Overwrite sign type", question1,
                                                 QMessageBox.Yes | QMessageBox.No)
                 if response == QMessageBox.Yes:
@@ -1157,7 +1157,7 @@ class MainWindow(QMainWindow):
 
     # paste any signs that are on the clipboard
     def paste_signs(self, listfromclipboard):
-        signstopaste = [Sign(serializedsign=itemtopaste.serialize(), makedeepcopy=True)
+        signstopaste = [deepcopysign(itemtopaste)
                         # can't use deepcopy with Models
                         for itemtopaste in listfromclipboard if isinstance(itemtopaste, Sign)]
         duplicatedinfoflags = [self.corpus.getsigninfoduplicatedincorpus(sign, allof=False) for sign in signstopaste]

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -256,11 +256,11 @@ class MainWindow(QMainWindow):
         action_new_sign.setCheckable(False)
 
         # delete sign
-        self.action_delete_sign = QAction(QIcon(self.app_ctx.icons['delete']), 'Delete sign(s)', parent=self)
+        self.action_delete_sign = QAction(QIcon(self.app_ctx.icons['delete']), 'Delete', parent=self)
         self.action_delete_sign.setEnabled(False)
-        self.action_delete_sign.setStatusTip('Delete the selected sign(s)')
+        self.action_delete_sign.setStatusTip('Delete the selected sign(s) or module(s)')
         self.action_delete_sign.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_Delete))
-        self.action_delete_sign.triggered.connect(self.on_action_delete_signs)
+        self.action_delete_sign.triggered.connect(self.on_action_delete)
         self.action_delete_sign.setCheckable(False)
 
         # preferences
@@ -666,7 +666,7 @@ class MainWindow(QMainWindow):
     #   "copy", "paste", or "delete"
     def handle_moduleaction_selected(self, action_str):
         if action_str == "delete":
-            self.on_action_delete_modules()
+            self.delete_modules()
         elif action_str == "copy":
             self.on_action_copy()
         elif action_str == "paste":
@@ -678,7 +678,7 @@ class MainWindow(QMainWindow):
         if action_str == "edit":
             self.on_action_edit_signs()
         elif action_str == "delete":
-            self.on_action_delete_signs()
+            self.on_action_delete()
         elif action_str == "copy":
             self.on_action_copy()
         elif action_str == "paste":
@@ -1360,9 +1360,21 @@ class MainWindow(QMainWindow):
             # edit the sign-level info
             self.signlevel_panel.handle_signlevelbutton_click()
 
+    # deletes the items currently selected in whichever panel has focus
+    #   (corpus view has focus --> delete signs)
+    #   (sign summary scene has focus --> delete modules)
+    def on_action_delete(self, clicked=None):
+        if self.corpus_display.corpus_view.hasFocus():
+            self.delete_signs()
+        elif self.signsummary_panel.scene.hasFocus():
+            self.delete_modules()
+        else:
+            # TODO: implement for other panels/objects (not just Corpus View / Signs or Sign Summary Scene / Modules)
+            pass
+
     # optionally provide a list of modules to delete, referenced by tuples of (uniqueid, moduletype)
     # if uids_types argument is not used, then the function deletes the modules currently selected in the sign summary panel
-    def on_action_delete_modules(self, clicked=None, uids_types=None):
+    def delete_modules(self, uids_types=None):
         if uids_types is None:
             selectedmodulebuttons = self.signsummary_panel.selectedmodulebuttons()
             # two buttons might point to the same module so make sure we don't report duplicated modules
@@ -1403,7 +1415,7 @@ class MainWindow(QMainWindow):
 
     # optionally provide a list of Signs to delete
     # if signs argument is not used, then the function deletes the signs currently selected in the corpus view
-    def on_action_delete_signs(self, clicked=None, signs=None):
+    def delete_signs(self, clicked=None, signs=None):
         if signs is None:
             signs = self.corpus_display.getselectedsigns()
 

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1091,6 +1091,7 @@ class MainWindow(QMainWindow):
             # focus is on the Sign Summary Panel, so we need to make sure we only paste clipboard object if they're modules
             signtypemodules = [mod for mod in listfromclipboard if isinstance(mod, Signtype)]
             for signtypemod in signtypemodules:
+                # if it's the same one as the sign we're already in (ie trying to copy/paste in same sign), do nothing
                 if self.current_sign.signtype == signtypemod:
                     pass  # do nothing
                 else:
@@ -1217,7 +1218,8 @@ class MainWindow(QMainWindow):
     def on_action_delete_modules(self, clicked=None, uids_types=None):
         if uids_types is None:
             selectedmodulebuttons = self.signsummary_panel.selectedmodulebuttons()
-            uids_types = [(btn.module_uniqueid, btn.moduletype) for btn in selectedmodulebuttons]
+            # two buttons might point to the same module so make sure we don't report duplicated modules
+            uids_types = list(set([(btn.module_uniqueid, btn.moduletype) for btn in selectedmodulebuttons]))
 
         modulenames = []
         for uid, mtype in uids_types:

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1078,8 +1078,7 @@ class MainWindow(QMainWindow):
 
         # confirm that the user is ok with timing being reset to whole sign, in case of x-slot structure mismatch
         mismatchedxslots_q = "The x-slot structures of the source and destination signs do not match."
-        mismatchedxslots_q += "\n\nEach pasted module will have its timing reset to the whole sign; "
-        mismatchedxslots_q += "you will need to open the pasted modules and re-specify timing for each."
+        mismatchedxslots_q += " If you proceed, you should manually check the timing options in the pasted module(s)."  # "Each pasted module will have its timing reset to the whole sign; "
         reset_xslots = False
 
         if len(parametermodules) > 0:

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1352,7 +1352,21 @@ class MainWindow(QMainWindow):
                 modulenames.append("Sign Type")
             else:
                 # it's one of the timed parameter modules
-                modulenames.append(ModuleTypes.abbreviations[mtype] + str(self.current_sign.getmodulenumbersdict(mtype)[uid]))
+                module_abbrev = ModuleTypes.abbreviations[mtype] + str(self.current_sign.getmodulenumbersdict(mtype)[uid])
+                associated_relation_comment = ""
+                # if it's loc or mov check if there's an associated relation module(s)
+                if mtype in [ModuleTypes.MOVEMENT, ModuleTypes.LOCATION]:
+                    relationslist = list(self.current_sign.relationmodules.values())
+                    relationslist = [rel for rel in relationslist if (
+                            rel.relationy.existingmodule and uid in rel.relationy.linkedmoduleids)]
+                    if len(relationslist) > 0:
+                        rel_abbrevs = [ModuleTypes.abbreviations[ModuleTypes.RELATION] +
+                                       str(self.current_sign.relationmodulenumbers[relmod.uniqueid])
+                                           for relmod in relationslist]
+                        associated_relation_comment = " (has associated module" + ("s " if len(relationslist) > 1 else " ") + ", ".join(rel_abbrevs) + ")"
+
+                modulenames.append(module_abbrev + associated_relation_comment)
+
         modulenamesstring = "\n".join(modulenames)
 
         question1 = "Do you want to delete the following selected module"

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1090,7 +1090,7 @@ class MainWindow(QMainWindow):
         if xslots_src.additionalfraction != xslots_dest.additionalfraction:
             differences.append("additional fraction of an x-slot")
         if set(xslots_src.fractionalpoints) != set(xslots_dest.fractionalpoints):
-            differences.append("visible fractions")
+            differences.append("fractional divisions within x-slots")
         if differences:
             # if x-slot structure doesn't match between source module and destination module(s), don't let user paste
             diff_str = "\n".join([" - " + diff for diff in differences])

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1166,10 +1166,11 @@ class MainWindow(QMainWindow):
         result = None
         if len(duplicatedinfostrings) == 0:
             # there were no duplicates; just paste everything
-            for signtopaste in signstopaste:
-                signtopaste.signlevel_information.entryid.counter = self.corpus.highestID + 1
-                self.corpus.add_sign(signtopaste)
-            self.corpus_display.updated_signs(signs=self.corpus.signs, current_sign=signtopaste)
+            if len(signstopaste) > 0:
+                for signtopaste in signstopaste:
+                    signtopaste.signlevel_information.entryid.counter = self.corpus.highestID + 1
+                    self.corpus.add_sign(signtopaste)
+                self.corpus_display.updated_signs(signs=self.corpus.signs, current_sign=signtopaste)
             return
         else:  # there were some duplicates; what does the user want to do?
             duplicateinfodialog = PastingDuplicateInfoDialog(duplicatedinfoflags, duplicatedinfostrings, parent=self)

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1078,7 +1078,11 @@ class MainWindow(QMainWindow):
 
         # confirm that the user is ok with timing being reset to whole sign, in case of x-slot structure mismatch
         mismatchedxslots_q = "The x-slot structures of the source and destination signs do not match."
-        mismatchedxslots_q += " If you proceed, you should manually check the timing options in the pasted module(s)."  # "Each pasted module will have its timing reset to the whole sign; "
+        mismatchedxslots_q += " If you proceed, you should manually check the timing options in the pasted module(s)."
+        # TODO KV remove once wording is confirmed
+        # "Each pasted module will have its timing reset to the whole sign; "
+        # mismatchedxslots_q += "you will need to open the pasted modules and re-specify timing for each."
+        # "The module to be pasted has a different number of x-slots than the current sign. If you proceed, you should manually check the timing options in the pasted module."
         reset_xslots = False
 
         if len(parametermodules) > 0 and self.app_settings['signdefaults']['xslot_generation'] != 'none':

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1089,11 +1089,15 @@ class MainWindow(QMainWindow):
                         response = QMessageBox.question(self, "Paste associated module" + suffix,
                                                         question1.format(mod_abbrev=rel_abbrev,
                                                                          suffix=suffix,
-                                                                         linked_abbrevs=anchor_abbrevs))
-                        if response == QMessageBox.Yes:
+                                                                         linked_abbrevs=anchor_abbrevs),
+                                                        QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel)
+                        if response == QMessageBox.Cancel:
+                            return
+                        elif response == QMessageBox.Yes:
                             for m in missinganchors:
                                 parametermodules.append(m)
                                 parameteruids.append(m.uniqueid)
+
 
             elif module.moduletype in [ModuleTypes.MOVEMENT, ModuleTypes.LOCATION]:
                 missingrels = list(self.copypaste_referencesign.relationmodules.values())
@@ -1111,8 +1115,11 @@ class MainWindow(QMainWindow):
                     response = QMessageBox.question(self, "Paste associated module" + suffix,
                                                     question1.format(mod_abbrev=anchor_abbrev,
                                                                      suffix=suffix,
-                                                                     linked_abbrevs=rel_abbrevs))
-                    if response == QMessageBox.Yes:
+                                                                     linked_abbrevs=rel_abbrevs),
+                                                    QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel)
+                    if response == QMessageBox.Cancel:
+                        return
+                    elif response == QMessageBox.Yes:
                         for m in missingrels:
                             parametermodules.append(m)
                             parameteruids.append(m.uniqueid)

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1066,7 +1066,7 @@ class MainWindow(QMainWindow):
                 question1 += "Note also that you must check for sign type compatibility (e.g. one-handed sign type vs "
                 question1 += "two-handed modules) yourself; SLP-AA has not done it for you. "
                 question1 += "Do you still want to paste the copied sign type into this sign?"
-                response = QMessageBox.question(self, "Paste sign type", question1,
+                response = QMessageBox.question(self, "Overwrite sign type", question1,
                                                 QMessageBox.Yes | QMessageBox.No)
                 if response == QMessageBox.Yes:
                     self.current_sign.signtype = deepcopy(signtypemod)

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1029,7 +1029,7 @@ class MainWindow(QMainWindow):
         selectedmodule_uids_types = list(set([(btn.module_uniqueid, btn.moduletype) for btn in selectedmodulebuttons]))
         selectedmodules = []
         for uid, mtype in selectedmodule_uids_types:
-            if mtype not in ModuleTypes.abbreviations.keys():  # or if uid == 0
+            if mtype not in ModuleTypes.parametertypes:  # or if uid == 0
                 # then it's the signtype module
                 selectedmodules.append(self.current_sign.signtype)
             else:

--- a/src/main/python/gui/main_window.py
+++ b/src/main/python/gui/main_window.py
@@ -1054,18 +1054,29 @@ class MainWindow(QMainWindow):
 
     # paste any modules that are on the clipboard
     def paste_modules(self, listfromclipboard):
+        # deal with copy/pasting signtype, if applicable
         signtypemodules = [mod for mod in listfromclipboard if isinstance(mod, Signtype)]
         for signtypemod in signtypemodules:
             # if it's the same one as the sign we're already in (ie trying to copy/paste in same sign), do nothing
             if self.current_sign.signtype == signtypemod:
-                pass  # do nothing
+                pass
             else:
-                self.current_sign.signtype = deepcopy(signtypemod)
-                self.signsummary_panel.refreshsign()
+                # otherwise paste, once we've confirmed that the user is ok with overwriting
+                question1 = "You are about to overwrite the existing sign type for this sign. "
+                question1 += "Note also that you must check for sign type compatibility (e.g. one-handed sign type vs "
+                question1 += "two-handed modules) yourself; SLP-AA has not done it for you. "
+                question1 += "Do you still want to paste the copied sign type into this sign?"
+                response = QMessageBox.question(self, "Paste sign type", question1,
+                                                QMessageBox.Yes | QMessageBox.No)
+                if response == QMessageBox.Yes:
+                    self.current_sign.signtype = deepcopy(signtypemod)
+                    self.signsummary_panel.refreshsign()
 
+        # deal with copy/pasting other modules, if applicable
         parametermodules = [mod for mod in listfromclipboard if isinstance(mod, ParameterModule)]
         parameteruids = [mod.uniqueid for mod in parametermodules]
 
+        # when copy/pasting a linked module but not its partner (mov or loc vs rel), ask user if they want to paste the partner(s) too
         question1 = "You are pasting {mod_abbrev} without its associated module{suffix}: {linked_abbrevs}. "
         question1 += "Do you want to paste the associated module{suffix} too?"
 

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -484,7 +484,7 @@ class AssociatedRelationsDialog(QDialog):
         else:
             self.relationslist = []
 
-        self.relations_listmodel.setmoduleslist(self.relationslist, self.relationmodulenumsdict, ModuleTypes.RELATION)
+        self.relations_listmodel.setmoduleslist(self.relationslist, self.relationmodulenumsdict)
 
 
 class AssociatedRelationsPanel(QFrame):

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import (
 )
 
 from gui.xslot_graphics import XslotLinkScene
-from lexicon.module_classes import AddedInfo, TimingInterval, TimingPoint, ParameterModule, ModuleTypes, LocationModule, MovementModule
+from lexicon.module_classes import AddedInfo, TimingInterval, TimingPoint, ParameterModule, LocationModule, MovementModule
 from models.relation_models import ModuleLinkingListModel
 from gui.movementspecification_view import MovementSpecificationPanel
 from gui.locationspecification_view import LocationSpecificationPanel
@@ -36,7 +36,7 @@ from gui.orientationspecification_view import OrientationSpecificationPanel
 from gui.nonmanualspecification_view import NonManualSpecificationPanel
 from gui.modulespecification_widgets import AddedInfoPushButton, ArticulatorSelector, PhonLocSelection
 from gui.link_help import show_help
-from constant import SIGN_TYPE, HAND, ARM, LEG
+from constant import SIGN_TYPE, HAND, ARM, LEG, ModuleTypes
 
 
 class ModuleSelectorDialog(QDialog):

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -761,7 +761,7 @@ class XslotLinkingPanel(QFrame):
             if xslots_src.additionalfraction != xslots_dest.additionalfraction:
                 differences.append("additional fraction of an x-slot")
             if set(xslots_src.fractionalpoints) != set(xslots_dest.fractionalpoints):
-                differences.append("visible fractions")
+                differences.append("fractional divisions within x-slots")
             if differences:
                 # if x-slot structure doesn't match between source module and destination module(s), don't let user paste
                 diff_str = "\n".join([" - " + diff for diff in differences])

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -30,7 +30,7 @@ from PyQt5.QtCore import (
     QSize
 )
 
-from gui.xslot_graphics import XslotLinkScene
+from gui.xslot_graphics import XslotLinkScene, XslotLinkSceneContextMenu, islistoftimingintervals
 from lexicon.module_classes import AddedInfo, TimingInterval, TimingPoint, ParameterModule, LocationModule, MovementModule
 from models.relation_models import ModuleLinkingListModel
 from gui.movementspecification_view import MovementSpecificationPanel
@@ -715,6 +715,7 @@ class XslotLinkingPanel(QFrame):
 
         self.xslotlinkscene = XslotLinkScene(timingintervals=self.timingintervals, parentwidget=self)
         self.xslotlinkscene.selection_changed.connect(self.selection_changed.emit)
+        self.xslotlinkscene.scene_Rclicked.connect(self.handle_xslotlinkscene_Rclick)
         self.xslotlinkview = QGraphicsView(self.xslotlinkscene)
         self.xslotlinkview.setFixedHeight(self.xslotlinkscene.scene_height + 50)
         # self.xslotlinkview.setFixedSize(self.xslotlinkscene.scene_width+100, self.xslotlinkscene.scene_height+50)
@@ -736,6 +737,57 @@ class XslotLinkingPanel(QFrame):
     def clear(self):
         self.xslotlinkscene = XslotLinkScene(parentwidget=self, timingintervals=[])
         self.xslotlinkview.setScene(self.xslotlinkscene)
+
+    def handle_xslotlinkscene_Rclick(self, mouseevent):
+        menu = XslotLinkSceneContextMenu(clipboardlist=self.mainwindow.clipboard)
+        menu.action_selected.connect(self.handle_timingaction_selected)
+        menu.exec_(mouseevent.screenPos())
+
+    def handle_timingaction_selected(self, action_str):
+        if action_str == "copy timing":
+            self.mainwindow.clipboard = self.timingintervals
+
+        elif action_str == "paste timing":
+            if not islistoftimingintervals(self.mainwindow.clipboard):
+                # at least some of clipboard contents is not timing info; don't attempt to paste
+                return
+
+            # check x-slot structure of source vs destination signs
+            xslots_src = self.mainwindow.copypaste_referencesign.xslotstructure
+            xslots_dest = self.mainwindow.current_sign.xslotstructure
+            differences = []
+            if xslots_src.number != xslots_dest.number:
+                differences.append("number of whole x-slots")
+            if xslots_src.additionalfraction != xslots_dest.additionalfraction:
+                differences.append("additional fraction of an x-slot")
+            if set(xslots_src.fractionalpoints) != set(xslots_dest.fractionalpoints):
+                differences.append("visible fractions")
+            if differences:
+                # if x-slot structure doesn't match between source module and destination module(s), don't let user paste
+                diff_str = "\n".join([" - " + diff for diff in differences])
+                QMessageBox.critical(self, "X-slot mismatch",
+                                     "Cannot paste timing: the x-slot structures of the source and destination signs do not match."
+                                     + "\nThey differ with respect to:"
+                                     + "\n" + diff_str)
+                return
+
+            # everything looks ok so far; get ready to paste timing into this module
+            # check for overwriting timing
+            thismoduletiming = self.gettimingintervals()
+            timingmismatches = [ti for ti in thismoduletiming if ti not in self.mainwindow.clipboard] \
+                               + [ti for ti in self.mainwindow.clipboard if ti not in thismoduletiming]
+            if thismoduletiming and timingmismatches:
+                response = QMessageBox.question(self, "Overwrite timing",
+                                                "You are about to overwrite the existing timing for this module. "
+                                                + "Do you still want to paste?",
+                                                QMessageBox.Ok | QMessageBox.Cancel)
+                if response == QMessageBox.Cancel:
+                    # don't paste timing into this current module
+                    return
+                else:
+                    # go ahead and paste
+                    self.clear()
+                    self.settimingintervals(self.mainwindow.clipboard) 
 
 
 class ArticulatorSelectionPanel(QFrame):

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -745,6 +745,7 @@ class XslotLinkingPanel(QFrame):
 
     def handle_timingaction_selected(self, action_str):
         if action_str == "copy timing":
+            self.mainwindow.copypaste_referencesign = self.mainwindow.current_sign
             self.mainwindow.clipboard = self.timingintervals
 
         elif action_str == "paste timing":

--- a/src/main/python/gui/modulespecification_widgets.py
+++ b/src/main/python/gui/modulespecification_widgets.py
@@ -237,33 +237,32 @@ class AddedInfoContextMenu(QMenu):
         self.info_added.emit(self.addedinfo)
 
 
-# menu associated with a module button/buttons in the sign summary panel, offering copy/paste/edit/delete functions
+# menu associated with a module button/buttons in the sign summary panel, offering copy/paste/delete functions
 class ModuleButtonContextMenu(QMenu):
     action_selected = pyqtSignal(str)  # "copy", "paste", or "delete"
 
-    # individual menu items are enabled/disabled based on TODO
-    def __init__(self, selected_buttons=None, clipboard_modules=None, whichactions=None):
+    # individual menu items are enabled/disabled based on whether any module buttons are selected (for copy or delete)
+    #   and whether there's anything on the clipboard (for paste)
+    def __init__(self, has_selected_buttons=False, has_clipboard_modules=False, whichactions=None):
         super().__init__()
-        selected_buttons = selected_buttons or []
-        clipboard_modules = clipboard_modules or []
         if whichactions is None:
             whichactions = ["copy", "paste", "delete"]  # seemed potentially messy to include "edit" so I didn't
 
         if "copy" in whichactions:
             self.copy_action = QAction("Copy module(s)")  # : " + str([btn.text for btn in selected_buttons]))
-            self.copy_action.setEnabled(len(selected_buttons) > 0)
+            self.copy_action.setEnabled(has_selected_buttons)
             self.copy_action.triggered.connect(lambda checked: self.action_selected.emit("copy"))
             self.addAction(self.copy_action)
 
         if "paste" in whichactions:
             self.paste_action = QAction("Paste module(s)")  # : " + str([btn.text for btn in selected_buttons]))
-            self.paste_action.setEnabled(len(clipboard_modules) > 0)
+            self.paste_action.setEnabled(has_clipboard_modules)
             self.paste_action.triggered.connect(lambda checked: self.action_selected.emit("paste"))
             self.addAction(self.paste_action)
 
         if "delete" in whichactions:
             self.delete_action = QAction("Delete module(s)")  # : " + str([btn.text for btn in selected_buttons]))
-            self.delete_action.setEnabled(len(selected_buttons) > 0)
+            self.delete_action.setEnabled(has_selected_buttons)
             self.delete_action.triggered.connect(lambda checked: self.action_selected.emit("delete"))
             self.addAction(self.delete_action)
 

--- a/src/main/python/gui/modulespecification_widgets.py
+++ b/src/main/python/gui/modulespecification_widgets.py
@@ -236,6 +236,35 @@ class AddedInfoContextMenu(QMenu):
         self.info_added.emit(self.addedinfo)
 
 
+# menu associated with a module button/buttons in the sign summary panel, offering copy/paste/edit/delete functions
+class ModuleButtonContextMenu(QMenu):
+    action_selected = pyqtSignal(str)  # TODO "copy", "edit", or "delete"
+
+    # individual menu items are enabled/disabled based on TODO
+    def __init__(self, selected_buttons):
+        super().__init__()
+
+        self.copy_action = QAction("Copy TODO modules: " + str([btn.text for btn in selected_buttons]))
+        self.copy_action.setEnabled(True)
+        # self.copy_action.triggered.connect(lambda checked: self.action_selected.emit("copy"))
+        self.addAction(self.copy_action)
+
+        self.paste_action = QAction("Paste TODO modules: " + str([btn.text for btn in selected_buttons]))
+        self.paste_action.setEnabled(True)
+        # self.paste_action.triggered.connect(lambda checked: self.action_selected.emit("paste"))
+        self.addAction(self.paste_action)
+
+        self.edit_action = QAction("Edit TODO modules: " + str([btn.text for btn in selected_buttons]))
+        self.edit_action.setEnabled(True)
+        # self.edit_action.triggered.connect(lambda checked: self.action_selected.emit("edit"))
+        self.addAction(self.edit_action)
+
+        self.delete_action = QAction("Delete TODO modules: " + str([btn.text for btn in selected_buttons]))
+        self.delete_action.setEnabled(True)
+        # self.delete_action.triggered.connect(lambda checked: self.action_selected.emit("delete"))
+        self.addAction(self.delete_action)
+
+
 # menu associated with a sign entry/entries in the corpus view, offering copy/paste/edit/delete functions
 class SignEntryContextMenu(QMenu):
     action_selected = pyqtSignal(str)  # "copy", "edit" (sign-level info), or "delete"

--- a/src/main/python/gui/modulespecification_widgets.py
+++ b/src/main/python/gui/modulespecification_widgets.py
@@ -246,7 +246,7 @@ class ModuleButtonContextMenu(QMenu):
         selected_buttons = selected_buttons or []
         clipboard_modules = clipboard_modules or []
         if whichactions is None:
-            whichactions = ["copy", "paste", "delete"]
+            whichactions = ["copy", "paste", "delete"]  # seemed potentially messy to include "edit" so I didn't
 
         if "copy" in whichactions:
             self.copy_action = QAction("Copy module(s)")  # : " + str([btn.text for btn in selected_buttons]))

--- a/src/main/python/gui/modulespecification_widgets.py
+++ b/src/main/python/gui/modulespecification_widgets.py
@@ -28,8 +28,8 @@ from PyQt5.QtGui import (
     QStandardItem,
 )
 
-from lexicon.module_classes import AddedInfo, PhonLocations, userdefinedroles as udr
-from constant import treepathdelimiter
+from lexicon.module_classes import AddedInfo, PhonLocations
+from constant import treepathdelimiter, userdefinedroles as udr
 
 
 class ModuleSpecificationPanel(QFrame):

--- a/src/main/python/gui/modulespecification_widgets.py
+++ b/src/main/python/gui/modulespecification_widgets.py
@@ -28,8 +28,8 @@ from PyQt5.QtGui import (
     QStandardItem,
 )
 
-from lexicon.module_classes import AddedInfo, treepathdelimiter, PhonLocations
-
+from lexicon.module_classes import AddedInfo, PhonLocations
+from constant import treepathdelimiter
 
 class ModuleSpecificationPanel(QFrame):
 
@@ -238,31 +238,33 @@ class AddedInfoContextMenu(QMenu):
 
 # menu associated with a module button/buttons in the sign summary panel, offering copy/paste/edit/delete functions
 class ModuleButtonContextMenu(QMenu):
-    action_selected = pyqtSignal(str)  # TODO "copy", "edit", or "delete"
+    action_selected = pyqtSignal(str)  # "copy", "paste", or "delete"
 
     # individual menu items are enabled/disabled based on TODO
-    def __init__(self, selected_buttons):
+    def __init__(self, selected_buttons=None, clipboard_modules=None, whichactions=None):
         super().__init__()
+        selected_buttons = selected_buttons or []
+        clipboard_modules = clipboard_modules or []
+        if whichactions is None:
+            whichactions = ["copy", "paste", "delete"]
 
-        self.copy_action = QAction("Copy TODO modules: " + str([btn.text for btn in selected_buttons]))
-        self.copy_action.setEnabled(True)
-        # self.copy_action.triggered.connect(lambda checked: self.action_selected.emit("copy"))
-        self.addAction(self.copy_action)
+        if "copy" in whichactions:
+            self.copy_action = QAction("Copy module(s)")  # : " + str([btn.text for btn in selected_buttons]))
+            self.copy_action.setEnabled(len(selected_buttons) > 0)
+            self.copy_action.triggered.connect(lambda checked: self.action_selected.emit("copy"))
+            self.addAction(self.copy_action)
 
-        self.paste_action = QAction("Paste TODO modules: " + str([btn.text for btn in selected_buttons]))
-        self.paste_action.setEnabled(True)
-        # self.paste_action.triggered.connect(lambda checked: self.action_selected.emit("paste"))
-        self.addAction(self.paste_action)
+        if "paste" in whichactions:
+            self.paste_action = QAction("Paste module(s)")  # : " + str([btn.text for btn in selected_buttons]))
+            self.paste_action.setEnabled(len(clipboard_modules) > 0)
+            self.paste_action.triggered.connect(lambda checked: self.action_selected.emit("paste"))
+            self.addAction(self.paste_action)
 
-        self.edit_action = QAction("Edit TODO modules: " + str([btn.text for btn in selected_buttons]))
-        self.edit_action.setEnabled(True)
-        # self.edit_action.triggered.connect(lambda checked: self.action_selected.emit("edit"))
-        self.addAction(self.edit_action)
-
-        self.delete_action = QAction("Delete TODO modules: " + str([btn.text for btn in selected_buttons]))
-        self.delete_action.setEnabled(True)
-        # self.delete_action.triggered.connect(lambda checked: self.action_selected.emit("delete"))
-        self.addAction(self.delete_action)
+        if "delete" in whichactions:
+            self.delete_action = QAction("Delete module(s)")  # : " + str([btn.text for btn in selected_buttons]))
+            self.delete_action.setEnabled(len(selected_buttons) > 0)
+            self.delete_action.triggered.connect(lambda checked: self.action_selected.emit("delete"))
+            self.addAction(self.delete_action)
 
 
 # menu associated with a sign entry/entries in the corpus view, offering copy/paste/edit/delete functions

--- a/src/main/python/gui/modulespecification_widgets.py
+++ b/src/main/python/gui/modulespecification_widgets.py
@@ -28,8 +28,8 @@ from PyQt5.QtGui import (
     QStandardItem,
 )
 
-from lexicon.module_classes import AddedInfo, PhonLocations
-from constant import treepathdelimiter, userdefinedroles as udr
+from lexicon.module_classes import AddedInfo, PhonLocations, TimingInterval, Signtype, ParameterModule
+from constant import treepathdelimiter, userdefinedroles as udr, ModuleTypes
 
 
 class ModuleSpecificationPanel(QFrame):
@@ -235,66 +235,6 @@ class AddedInfoContextMenu(QMenu):
         self.addedinfo.other_note = self.other_action.text()
 
         self.info_added.emit(self.addedinfo)
-
-
-# menu associated with a module button/buttons in the sign summary panel, offering copy/paste/delete functions
-class ModuleButtonContextMenu(QMenu):
-    action_selected = pyqtSignal(str)  # "copy", "paste", or "delete"
-
-    # individual menu items are enabled/disabled based on whether any module buttons are selected (for copy or delete)
-    #   and whether there's anything on the clipboard (for paste)
-    def __init__(self, has_selected_buttons=False, has_clipboard_modules=False, whichactions=None):
-        super().__init__()
-        if whichactions is None:
-            whichactions = ["copy", "paste", "delete"]  # seemed potentially messy to include "edit" so I didn't
-
-        if "copy" in whichactions:
-            self.copy_action = QAction("Copy module(s)")  # : " + str([btn.text for btn in selected_buttons]))
-            self.copy_action.setEnabled(has_selected_buttons)
-            self.copy_action.triggered.connect(lambda checked: self.action_selected.emit("copy"))
-            self.addAction(self.copy_action)
-
-        if "paste" in whichactions:
-            self.paste_action = QAction("Paste module(s)")  # : " + str([btn.text for btn in selected_buttons]))
-            self.paste_action.setEnabled(has_clipboard_modules)
-            self.paste_action.triggered.connect(lambda checked: self.action_selected.emit("paste"))
-            self.addAction(self.paste_action)
-
-        if "delete" in whichactions:
-            self.delete_action = QAction("Delete module(s)")  # : " + str([btn.text for btn in selected_buttons]))
-            self.delete_action.setEnabled(has_selected_buttons)
-            self.delete_action.triggered.connect(lambda checked: self.action_selected.emit("delete"))
-            self.addAction(self.delete_action)
-
-
-# menu associated with a sign entry/entries in the corpus view, offering copy/paste/edit/delete functions
-class SignEntryContextMenu(QMenu):
-    action_selected = pyqtSignal(str)  # "copy", "edit" (sign-level info), or "delete"
-
-    # individual menu items are enabled/disabled based on whether any signs are currently selected
-    #   and/or whether there are any signs on the clipboard
-    def __init__(self, has_selectedsigns, has_clipboardsigns):
-        super().__init__()
-
-        self.copy_action = QAction("Copy Sign(s)")
-        self.copy_action.setEnabled(has_selectedsigns)
-        self.copy_action.triggered.connect(lambda checked: self.action_selected.emit("copy"))
-        self.addAction(self.copy_action)
-
-        self.paste_action = QAction("Paste Sign(s)")
-        self.paste_action.setEnabled(has_clipboardsigns)
-        self.paste_action.triggered.connect(lambda checked: self.action_selected.emit("paste"))
-        self.addAction(self.paste_action)
-
-        self.edit_action = QAction("Edit Sign-level Info(s)")
-        self.edit_action.setEnabled(has_selectedsigns)
-        self.edit_action.triggered.connect(lambda checked: self.action_selected.emit("edit"))
-        self.addAction(self.edit_action)
-
-        self.delete_action = QAction("Delete Sign(s)")
-        self.delete_action.setEnabled(has_selectedsigns)
-        self.delete_action.triggered.connect(lambda checked: self.action_selected.emit("delete"))
-        self.addAction(self.delete_action)
 
 
 class AbstractLocationAction(QWidgetAction):

--- a/src/main/python/gui/movementspecification_view.py
+++ b/src/main/python/gui/movementspecification_view.py
@@ -22,11 +22,11 @@ from PyQt5.QtCore import (
     QItemSelectionModel
 )
 
-from lexicon.module_classes import userdefinedroles as udr, MovementModule
+from lexicon.module_classes import MovementModule
 from models.movement_models import MovementTreeModel, MovementPathsProxyModel, MovementTreeItem
 from serialization_classes import MovementTreeSerializable
 from gui.modulespecification_widgets import AddedInfoContextMenu, ModuleSpecificationPanel, TreeListView, TreePathsListItemDelegate, TreeSearchComboBox
-from constant import HAND
+from constant import HAND, userdefinedroles as udr
 
 
 class MovementTreeView(QTreeView):

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -463,6 +463,8 @@ class SignSummaryPanel(QScrollArea):
             modules = [mod for mod in self.sign.getmoduledict(moduletype).values() if
                        mod.articulators is not None and
                        (mod.articulators[0] == LEG and True in mod.articulators[1].values())]
+        modulenumbers = self.sign.getmodulenumbersdict(moduletype)  # added back in
+        moduletypeabbrev = ModuleTypes.abbreviations[moduletype]  # added back in
 
         mods_count = len(modules)
         if mods_count > 0:
@@ -488,19 +490,18 @@ class SignSummaryPanel(QScrollArea):
                 points = []
 
                 for mod in modules:
-                    modabbrev = self.sign.getmoduleabbreviation(module=mod)
                     m_id = mod.uniqueid
                     condensed_timingintervals = self.condense_timingintervals(mod.timingintervals)
                     for t in condensed_timingintervals:
                         if t.ispoint():
-                            points.append((m_id, t))
+                            points.append((modulenumbers[m_id], m_id, t))
                         else:
-                            intervals.append((m_id, t))
+                            intervals.append((modulenumbers[m_id], m_id, t))
 
                 if len(intervals) > 0:
-                    self.addmoduleintervals(None, None, intervals, moduletype, modabbrev, modules)
+                    self.addmoduleintervals(None, None, intervals, moduletype, moduletypeabbrev, modules)
                 if len(points) > 0:
-                    self.addmodulepoints(None, None, points, moduletype, modabbrev, modules)
+                    self.addmodulepoints(None, None, points, moduletype, moduletypeabbrev, modules)
             self.assign_hover_partners()
 
     def addmodules_hands_arms(self, artnum, moduletype):
@@ -513,6 +514,8 @@ class SignSummaryPanel(QScrollArea):
             modules = [mod for mod in self.sign.getmoduledict(moduletype).values() if
                        mod.articulators is not None and
                        (mod.articulators[0] in [HAND, ARM] and mod.articulators[1][artnum])]
+        modulenumbers = self.sign.getmodulenumbersdict(moduletype)
+        moduletypeabbrev = ModuleTypes.abbreviations[moduletype]
 
         mods_count = len(modules)
         if mods_count > 0:
@@ -549,7 +552,6 @@ class SignSummaryPanel(QScrollArea):
                 points = {}
 
                 for mod in modules:
-                    moduleabbrev = self.sign.getmoduleabbreviation(module=mod)
                     m_id = mod.uniqueid
                     if isrel:
                         if mod.usesarticulator(HAND, artnum):
@@ -568,17 +570,17 @@ class SignSummaryPanel(QScrollArea):
                             if t.ispoint():
                                 if articulator not in points.keys():
                                     points[articulator] = []
-                                points[articulator].append((m_id, t))
+                                points[articulator].append((modulenumbers[m_id], m_id, t))
                             else:
                                 if articulator not in intervals.keys():
                                     intervals[articulator] = []
-                                intervals[articulator].append((m_id, t))
+                                intervals[articulator].append((modulenumbers[m_id], m_id, t))
 
                 for articulator in [HAND, ARM]:  # , LEG]:
                     if articulator in intervals and len(intervals[articulator]) > 0:
-                        self.addmoduleintervals(articulator, artnum, intervals[articulator], moduletype, moduleabbrev, modules)
+                        self.addmoduleintervals(articulator, artnum, intervals[articulator], moduletype, moduletypeabbrev, modules)
                     if articulator in points and len(points[articulator]) > 0:
-                        self.addmodulepoints(articulator, artnum, points[articulator], moduletype, moduleabbrev, modules)
+                        self.addmodulepoints(articulator, artnum, points[articulator], moduletype, moduletypeabbrev, modules)
             self.assign_hover_partners()
 
     def condense_timingintervals(self, intervals):
@@ -620,11 +622,11 @@ class SignSummaryPanel(QScrollArea):
 
         return condensed_intervals
 
-    def addmoduleintervals(self, articulator, artnum, intervals, moduletype, moduleabbrev, modules):
+    def addmoduleintervals(self, articulator, artnum, intervals, moduletype, moduletypeabbrev, modules):
         self.current_y += self.default_xslot_height + self.verticalspacing
-        for i_idx, (m_id, t) in enumerate(intervals):
+        for i_idx, (modnum, m_id, t) in enumerate(intervals):
             paramrect = XslotRectModuleButton(self, module_uniqueid=m_id,
-                                              text=((ARTICULATOR_ABBREVS[articulator] + str(artnum) + ".") if articulator is not None else "") + moduleabbrev,
+                                              text=((ARTICULATOR_ABBREVS[articulator] + str(artnum) + ".") if articulator is not None else "") + moduletypeabbrev + str(modnum),
                                               moduletype=moduletype,
                                               sign=self.sign)
             paramabbrev = [mod for mod in modules if mod.uniqueid == m_id][0].getabbreviation()
@@ -663,13 +665,13 @@ class SignSummaryPanel(QScrollArea):
             modifiedtext = text[dotindex+1:]
         return modifiedtext
 
-    def addmodulepoints(self, articulator, artnum, points, moduletype, moduleabbrev, modules):
+    def addmodulepoints(self, articulator, artnum, points, moduletype, moduletypeabbrev, modules):
         if len(points) > 0:
             self.current_y += self.default_xslot_height + self.verticalspacing
 
-        for i_idx, (m_id, t) in enumerate(points):
+        for i_idx, (modnum, m_id, t) in enumerate(points):
             paramellipse = XslotEllipseModuleButton(self, module_uniqueid=m_id,
-                                                    text=((ARTICULATOR_ABBREVS[articulator] + str(artnum) + ".") if articulator is not None else "") + moduleabbrev,
+                                                    text=((ARTICULATOR_ABBREVS[articulator] + str(artnum) + ".") if articulator is not None else "") + moduletypeabbrev + str(modnum),
                                                     moduletype=moduletype,
                                                     sign=self.sign)
             paramabbrev = [mod for mod in modules if mod.uniqueid == m_id][0].getabbreviation()

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -311,15 +311,6 @@ class SignSummaryPanel(QScrollArea):
             if self.mainwindow.current_sign is not None:
                 self.sign = self.mainwindow.current_sign
 
-            self.relmodnums = self.sign.getmodulenumbersdict(ModuleTypes.RELATION)
-            self.relmods_hands_arms = []
-            self.relmods_other = []
-            for rmod in self.sign.getmoduledict(ModuleTypes.RELATION).values():
-                if rmod.usesarticulator(HAND) or rmod.usesarticulator(ARM):
-                    self.relmods_hands_arms.append(rmod)
-                else:
-                    self.relmods_other.append(rmod)
-
         for sceneitem in self.scene.items():
             self.scene.removeItem(sceneitem)
 
@@ -339,6 +330,15 @@ class SignSummaryPanel(QScrollArea):
 
         if self.sign is None:
             return
+
+        self.relmodnums = self.sign.getmodulenumbersdict(ModuleTypes.RELATION)
+        self.relmods_hands_arms = []
+        self.relmods_other = []
+        for rmod in self.sign.getmoduledict(ModuleTypes.RELATION).values():
+            if rmod.usesarticulator(HAND) or rmod.usesarticulator(ARM):
+                self.relmods_hands_arms.append(rmod)
+            else:
+                self.relmods_other.append(rmod)
 
         self.addsigntype()
         self.addxslots()

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -754,8 +754,8 @@ class SignSummaryPanel(QScrollArea):
 
         if numclicks == 1 and mousebutton == Qt.RightButton and not ctrlmodifier:
             # provide a context menu with options that apply to all currently-selected buttons
-            menu = ModuleButtonContextMenu(selected_buttons=self.selectedmodulebuttons(),
-                                           clipboard_modules=self.getclipboardmodules())
+            menu = ModuleButtonContextMenu(has_selected_buttons=len(self.selectedmodulebuttons()) > 0,
+                                           has_clipboard_modules=len(self.getclipboardmodules()) > 0)
             menu.action_selected.connect(self.action_selected.emit)
             # don't let the user paste if x-slots are on but they haven't yet specified a structure for this sign
             menu.setEnabled(self.mainwindow.app_settings['signdefaults']['xslot_generation'] == 'none' or (self.sign is not None and self.sign.specifiedxslots))
@@ -790,7 +790,7 @@ class SignSummaryPanel(QScrollArea):
                         # the user is selecting this one as they right-click on it
                         self.selectonemodulebutton(modulebutton)
                     # provide a context menu with options that apply to all currently-selected buttons
-                    menu = ModuleButtonContextMenu(selected_buttons=self.selectedmodulebuttons(), clipboard_modules=self.getclipboardmodules())
+                    menu = ModuleButtonContextMenu(has_selected_buttons=len(self.selectedmodulebuttons()) > 0, has_clipboard_modules=len(self.getclipboardmodules()) > 0)
                     menu.action_selected.connect(self.action_selected.emit)
                     menu.exec_(mouseevent.screenPos())
             elif numclicks == 2 and mousebutton == Qt.LeftButton:

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -755,8 +755,7 @@ class SignSummaryPanel(QScrollArea):
         if numclicks == 1 and mousebutton == Qt.RightButton and not ctrlmodifier:
             # provide a context menu with options that apply to all currently-selected buttons
             menu = ModuleButtonContextMenu(selected_buttons=self.selectedmodulebuttons(),
-                                           clipboard_modules=self.getclipboardmodules(),
-                                           whichactions=["paste"])
+                                           clipboard_modules=self.getclipboardmodules())
             menu.action_selected.connect(self.action_selected.emit)
             # don't let the user paste if x-slots are on but they haven't yet specified a structure for this sign
             menu.setEnabled(self.mainwindow.app_settings['signdefaults']['xslot_generation'] == 'none' or (self.sign is not None and self.sign.specifiedxslots))

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -752,8 +752,9 @@ class SignSummaryPanel(QScrollArea):
         ctrlmodifier = mouseevent.modifiers() & Qt.ControlModifier
         mousebutton = mouseevent.button()
 
-        if numclicks == 1 and mousebutton == Qt.RightButton and not ctrlmodifier:
+        if numclicks == 1 and mousebutton == Qt.RightButton and not ctrlmodifier and self.scene.last_menu_pos != mouseevent.scenePos():
             # provide a context menu with options that apply to all currently-selected buttons
+            self.scene.last_menu_pos = mouseevent.scenePos()
             menu = ModuleButtonContextMenu(has_selected_buttons=len(self.selectedmodulebuttons()) > 0,
                                            has_clipboard_modules=len(self.getclipboardmodules()) > 0)
             menu.action_selected.connect(self.action_selected.emit)
@@ -790,6 +791,7 @@ class SignSummaryPanel(QScrollArea):
                         # the user is selecting this one as they right-click on it
                         self.selectonemodulebutton(modulebutton)
                     # provide a context menu with options that apply to all currently-selected buttons
+                    self.scene.last_menu_pos = mouseevent.scenePos()
                     menu = ModuleButtonContextMenu(has_selected_buttons=len(self.selectedmodulebuttons()) > 0, has_clipboard_modules=len(self.getclipboardmodules()) > 0)
                     menu.action_selected.connect(self.action_selected.emit)
                     menu.exec_(mouseevent.screenPos())

--- a/src/main/python/gui/panel.py
+++ b/src/main/python/gui/panel.py
@@ -279,6 +279,7 @@ class SignSummaryPanel(QScrollArea):
         self.scene = SignSummaryScene()
         self.scene.modulerect_clicked.connect(self.handle_summarymodulebtn_clicked)
         self.scene.moduleellipse_clicked.connect(self.handle_summarymodulebtn_clicked)
+        self.scene.scenebg_clicked.connect(self.handle_summaryscenebg_clicked)
 
         self.scene_width = 1100
         self.xslots_width = 1000
@@ -743,29 +744,23 @@ class SignSummaryPanel(QScrollArea):
         for otherside in btn.samemodule_buttons:
             otherside.setSelected(True)
 
-    # # TODO describe
-    # def handle_summaryscene_clicked(self, numclicks, mouseevent):
-    #     return
-    #     # ctrlmodifier = mouseevent.modifiers() & Qt.ControlModifier
-    #     # mousebutton = mouseevent.button()
-    #     #
-    #     # if numclicks == 1 and mousebutton == Qt.RightButton and not ctrlmodifier:
-    #     #     itemclicked = self.scene.itemAt(mouseevent.scenePos().x(), mouseevent.scenePos().y(), QTransform.TxNone)
-    #     #     if itemclicked is not None and (isinstance(itemclicked, XslotRectModuleButton) or isinstance(itemclicked, XslotEllipseModuleButton)):
-    #     #
-    #     #         clipboard = self.mainwindow.clipboard
-    #     #         clipboardmodules = []
-    #     #         if isinstance(clipboard, ParameterModule) or isinstance(clipboard, Signtype):
-    #     #             clipboardmodules.append(clipboard)
-    #     #         elif isinstance(clipboard, list):
-    #     #             for copieditem in clipboard:
-    #     #                 if isinstance(clipboard, ParameterModule) or isinstance(clipboard, Signtype):
-    #     #                     clipboardmodules.append(copieditem)
-    #     #
-    #     #         menu = ModuleButtonContextMenu(clipboard_modules=clipboardmodules, whichactions=["paste"])
-    #     #         menu.action_selected.connect(self.action_selected.emit)
-    #     #         menu.exec_(mouseevent.screenPos())
-    #     #         # TODO finish/check implementation
+
+    # single-R-click alone --> open a context menu with options that apply to all currently-selected buttons
+    #   ... which essentially means only 'paste', since clicking on the background only will de-select any that could
+    #   have potentially been used as inputs to copy or delete functions
+    def handle_summaryscenebg_clicked(self, numclicks, mouseevent):
+        ctrlmodifier = mouseevent.modifiers() & Qt.ControlModifier
+        mousebutton = mouseevent.button()
+
+        if numclicks == 1 and mousebutton == Qt.RightButton and not ctrlmodifier:
+            # provide a context menu with options that apply to all currently-selected buttons
+            menu = ModuleButtonContextMenu(selected_buttons=self.selectedmodulebuttons(),
+                                           clipboard_modules=self.getclipboardmodules(),
+                                           whichactions=["paste"])
+            menu.action_selected.connect(self.action_selected.emit)
+            # don't let the user paste if x-slots are on but they haven't yet specified a structure for this sign
+            menu.setEnabled(self.mainwindow.app_settings['signdefaults']['xslot_generation'] == 'none' or (self.sign is not None and self.sign.specifiedxslots))
+            menu.exec_(mouseevent.screenPos())
 
     # ctrl + single-L-click --> just toggle this button, regardless of whether any others are selected
     # single-L-click alone --> select this button (whether already selected or not) and deselect any/all others

--- a/src/main/python/gui/preference_dialog.py
+++ b/src/main/python/gui/preference_dialog.py
@@ -5,8 +5,6 @@ from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
-    QLayout,
-    QSizePolicy,
     QFormLayout,
     QTabWidget,
     QSpinBox,
@@ -19,17 +17,14 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QPushButton,
     QComboBox,
-    QSpacerItem
 )
 
 from PyQt5.QtCore import pyqtSignal, QSettings
 from gui.link_help import show_help
-from constant import FRACTION_CHAR, HAND, ARM, LEG, DEFAULT_LOC_2H, DEFAULT_LOC_1H
+from constant import FRACTION_CHAR, DEFAULT_LOC_2H, DEFAULT_LOC_1H
 from fractions import Fraction
-from lexicon.module_classes import treepathdelimiter, LocationModule
 from gui.locationspecification_view import LocationOptionsSelectionPanel, LocationType
 from models.location_models import LocationTreeModel
-from serialization_classes import LocationTableSerializable
 from gui.helper_widget import OptionSwitch
 
 

--- a/src/main/python/gui/relationspecification_view.py
+++ b/src/main/python/gui/relationspecification_view.py
@@ -781,9 +781,9 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
     # update the list of existing modules according to which module type was selected
     def update_existingmodule_list(self, selection_dict):
         if selection_dict[1]:
-            self.existingmodule_listmodel.setmoduleslist(self.locmodslist, self.locmodnums, ModuleTypes.LOCATION)
+            self.existingmodule_listmodel.setmoduleslist(self.locmodslist, self.locmodnums)
         elif selection_dict[2]:
-            self.existingmodule_listmodel.setmoduleslist(self.movmodslist, self.movmodnums, ModuleTypes.MOVEMENT)
+            self.existingmodule_listmodel.setmoduleslist(self.movmodslist, self.movmodnums)
         else:
             self.existingmodule_listmodel.setmoduleslist(None)
 

--- a/src/main/python/gui/relationspecification_view.py
+++ b/src/main/python/gui/relationspecification_view.py
@@ -11,12 +11,9 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QSpacerItem,
     QSizePolicy,
-    QPushButton
 )
 
 from PyQt5.QtCore import (
-    Qt,
-    QEvent,
     pyqtSignal,
     QItemSelectionModel
 )
@@ -30,7 +27,6 @@ from lexicon.module_classes import (
     Direction,
     RelationX,
     RelationY,
-    ModuleTypes,
     ContactRelation,
     ContactType,
     BodypartInfo
@@ -40,7 +36,7 @@ from models.location_models import BodypartTreeModel
 from gui.modulespecification_widgets import ModuleSpecificationPanel, SpecifyBodypartPushButton
 from gui.bodypartspecification_dialog import BodypartSelectorDialog
 from gui.helper_widget import OptionSwitch
-from constant import HAND, ARM, LEG
+from constant import HAND, ARM, LEG, ModuleTypes
 
 
 # This panel contains all the relation-specific options for users to define an instance of a Relation module.

--- a/src/main/python/gui/signtypespecification_view.py
+++ b/src/main/python/gui/signtypespecification_view.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import (
 from gui.modulespecification_dialog import AddedInfoPushButton
 from gui.link_help import show_help
 from lexicon.module_classes import Signtype
-from constant import SIGN_TYPE
+from constant import SIGN_TYPE, ModuleTypes
 
 
 class SigntypeSpecificationPanel(QFrame):
@@ -524,7 +524,7 @@ class SigntypeSelectorDialog(QDialog):
             self.reject()
 
         elif standard == QDialogButtonBox.Help:
-            show_help('signtype')
+            show_help(ModuleTypes.SIGNTYPE)
 
         #     elif standard == QDialogButtonBox.RestoreDefaults:
         #         self.movement_tab.remove_all_pages()

--- a/src/main/python/gui/xslot_graphics.py
+++ b/src/main/python/gui/xslot_graphics.py
@@ -354,13 +354,13 @@ class SignSummaryScene(QGraphicsScene):
         super().mouseReleaseEvent(event)
 
         itemsatclick = self.items(QPointF(event.scenePos().x(), event.scenePos().y()))
-        for sceneitem in itemsatclick:
-            if isinstance(sceneitem, XslotRectModuleButton) or isinstance(sceneitem, XslotEllipseModuleButton):
-                return  # don't do anything, because the menu will be spawned by the module button
-
-        # if we've run through all the items at the click point and none of them are module buttons,
-        #   then show the menu via the scene background
-        self.scenebg_clicked.emit(1, event)
+        modulebuttonsatclick = [sceneitem for sceneitem in itemsatclick if isinstance(sceneitem, XslotRectModuleButton) or isinstance(sceneitem, XslotEllipseModuleButton)]
+        if len(modulebuttonsatclick) > 0:
+            return  # don't do anything, because the menu will be spawned by the module button
+        else:
+            # we've run through all the items at the click point and none of them are module buttons,
+            #   so show the menu via the scene background
+            self.scenebg_clicked.emit(1, event)
 
 
 class XSlotCheckbox(QGraphicsRectItem):

--- a/src/main/python/gui/xslot_graphics.py
+++ b/src/main/python/gui/xslot_graphics.py
@@ -350,15 +350,20 @@ class SignSummaryScene(QGraphicsScene):
     moduleellipse_clicked = pyqtSignal(XslotEllipseModuleButton, int, QGraphicsSceneMouseEvent)
     scenebg_clicked = pyqtSignal(int, QGraphicsSceneMouseEvent)
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.last_menu_pos = QPointF(0, 0)
+
     def mouseReleaseEvent(self, event):
         super().mouseReleaseEvent(event)
 
         itemsatclick = self.items(QPointF(event.scenePos().x(), event.scenePos().y()))
         modulebuttonsatclick = [sceneitem for sceneitem in itemsatclick if isinstance(sceneitem, XslotRectModuleButton) or isinstance(sceneitem, XslotEllipseModuleButton)]
         if len(modulebuttonsatclick) > 0:
-            return  # don't do anything, because the menu will be spawned by the module button
+            # don't do anything, because the menu at this click point will be spawned by the module button instead
+            return
         else:
-            # we've run through all the items at the click point and none of them are module buttons,
+            # we've checked all the items at the click point and none of them are module buttons,
             #   so show the menu via the scene background
             self.scenebg_clicked.emit(1, event)
 

--- a/src/main/python/gui/xslot_graphics.py
+++ b/src/main/python/gui/xslot_graphics.py
@@ -20,6 +20,7 @@ from PyQt5.QtGui import (
 from PyQt5.QtCore import (
     Qt,
     pyqtSignal,
+    QPointF
 )
 
 from lexicon.module_classes import TimingPoint, TimingInterval
@@ -347,6 +348,19 @@ class SignSummaryScene(QGraphicsScene):
     # button that was clicked, single vs double click, mouseevent
     modulerect_clicked = pyqtSignal(XslotRectModuleButton, int, QGraphicsSceneMouseEvent)
     moduleellipse_clicked = pyqtSignal(XslotEllipseModuleButton, int, QGraphicsSceneMouseEvent)
+    scenebg_clicked = pyqtSignal(int, QGraphicsSceneMouseEvent)
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+
+        itemsatclick = self.items(QPointF(event.scenePos().x(), event.scenePos().y()))
+        for sceneitem in itemsatclick:
+            if isinstance(sceneitem, XslotRectModuleButton) or isinstance(sceneitem, XslotEllipseModuleButton):
+                return  # don't do anything, because the menu will be spawned by the module button
+
+        # if we've run through all the items at the click point and none of them are module buttons,
+        #   then show the menu via the scene background
+        self.scenebg_clicked.emit(1, event)
 
 
 class XSlotCheckbox(QGraphicsRectItem):

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-from datetime import datetime
 from copy import deepcopy
 
 from serialization_classes import LocationModuleSerializable, MovementModuleSerializable, RelationModuleSerializable

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -317,6 +317,12 @@ class Sign:
         else:
             self.getmoduledict(moduletype).pop(uniqueid)
             self.removemodulenumber(uniqueid, moduletype)
+            if moduletype in [ModuleTypes.LOCATION, ModuleTypes.MOVEMENT]:
+                # update any Relation modules that contain references to this anchor module
+                relationslist = list(self.relationmodules.values())
+                for relmod in relationslist:
+                    if relmod.relationy.existingmodule and uniqueid in relmod.relationy.linkedmoduleids:
+                        relmod.relationy.linkedmoduleids.remove(uniqueid)
         self.lastmodifiednow()
 
     def removemodulenumber(self, uniqueid, moduletype):

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -188,8 +188,8 @@ class Sign:
             modulenum = self.getmodulenumbersdict(moduletype).pop(old_uniqueid)
 
             # set uniqueID and re-add content to dicts with new uniqueID
-            new_uniqueid = datetime.timestamp(datetime.now())
-            module.uniqueid = new_uniqueid
+            module.uniqueid_reset()
+            new_uniqueid = module.uniqueid
             self.getmoduledict(moduletype)[new_uniqueid] = module
             self.getmodulenumbersdict(moduletype)[new_uniqueid] = modulenum
 

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -136,6 +136,15 @@ class Sign:
 
         return uid_updates
 
+    def getmoduleabbreviation(self, module=None, mod_type=None, mod_uid=None):
+        if module is not None:
+            mod_type = module.moduletype
+            mod_uid = module.uniqueid
+        elif mod_type is None or mod_uid is None:
+            return ""
+        modnum = self.getmodulenumbersdict(mod_type)[mod_uid]
+        return ModuleTypes.abbreviations[mod_type] + str(modnum)
+
     def numbermodules(self, moduletype):
         moduledict = self.getmoduledict(moduletype)
         modulenumbersdict = {}
@@ -196,7 +205,6 @@ class Sign:
             'cfg modules': self.handconfigmodules,
             'cfg module numbers': self.handconfigmodulenumbers,
         }
-
 
     def serializemovementmodules(self):
         serialized = {}

--- a/src/main/python/lexicon/lexicon_classes.py
+++ b/src/main/python/lexicon/lexicon_classes.py
@@ -5,12 +5,11 @@ from datetime import datetime
 from copy import deepcopy
 
 from serialization_classes import LocationModuleSerializable, MovementModuleSerializable, RelationModuleSerializable
-from lexicon.module_classes import SignLevelInformation, MovementModule, LocationModule, ModuleTypes, BodypartInfo, RelationX, RelationY, Direction, RelationModule, treepathdelimiter
-from gui.signtypespecification_view import Signtype
+from lexicon.module_classes import SignLevelInformation, MovementModule, LocationModule, BodypartInfo, RelationX, RelationY, Direction, RelationModule
 from gui.xslotspecification_view import XslotStructure
 from models.movement_models import MovementTreeModel
 from models.location_models import LocationTreeModel, BodypartTreeModel
-from constant import HAND, ARM, LEG
+from constant import HAND, ARM, LEG, ModuleTypes, treepathdelimiter
 
 NULL = '\u2205'
 glossesdelimiter = " / "
@@ -94,7 +93,7 @@ class Sign:
         # movement, relation, and location are all partially deep-copied already because of the need to serialize their underlying models
         # however, we will still need to assign new unique IDs to the copies in order to fully deep-copy these modules
         if moduletype == ModuleTypes.MOVEMENT:
-            self.unserializemovementmodules(serializedsign['mov modules'])
+            self.movementmodules = unserializemovementmodules(serializedsign['mov modules'])
             if makedeepcopy:
                 self.movementmodulenumbers = deepcopy(serializedsign['mov module numbers']) \
                     if 'mov module numbers' in serializedsign.keys() else self.numbermodules(moduletype)
@@ -103,7 +102,7 @@ class Sign:
                     if 'mov module numbers' in serializedsign.keys() else self.numbermodules(moduletype)
         elif moduletype == ModuleTypes.RELATION:
             # backward compatibility
-            self.unserializerelationmodules(serializedsign['rel modules' if 'rel modules' in serializedsign.keys() else 'con modules'])
+            self.relationmodules = unserializerelationmodules(serializedsign['rel modules' if 'rel modules' in serializedsign.keys() else 'con modules'])
             if makedeepcopy:
                 self.relationmodulenumbers = deepcopy(serializedsign['rel module numbers']) \
                     if 'rel module numbers' in serializedsign.keys() else self.numbermodules(moduletype)
@@ -111,7 +110,9 @@ class Sign:
                 self.relationmodulenumbers = serializedsign['rel module numbers'] \
                     if 'rel module numbers' in serializedsign.keys() else self.numbermodules(moduletype)
         elif moduletype == ModuleTypes.LOCATION:
-            self.unserializelocationmodules(serializedsign['loc modules'])
+            locmodules, relmodules = unserializelocationmodules(serializedsign['loc modules'])
+            self.addmodules(relmodules)
+            self.locationmodules = locmodules
             if makedeepcopy:
                 self.locationmodulenumbers = deepcopy(serializedsign['loc module numbers']) \
                     if 'loc module numbers' in serializedsign.keys() else self.numbermodules(moduletype)
@@ -241,155 +242,17 @@ class Sign:
             serialized[k] = MovementModuleSerializable(self.movementmodules[k])
         return serialized
 
-    def unserializemovementmodules(self, serialized_mvmtmodules):
-        unserialized = {}
-        for k in serialized_mvmtmodules.keys():
-            serialmodule = serialized_mvmtmodules[k]
-            mvmttreemodel = MovementTreeModel(serialmodule.movementtree)
-            articulators = serialmodule.articulators
-            inphase = serialmodule.inphase if (hasattr(serialmodule, 'inphase') and serialmodule.inphase is not None) else 0
-            timingintervals = serialmodule.timingintervals
-            addedinfo = serialmodule.addedinfo
-            phonlocs = serialmodule.phonlocs
-            unserialized[k] = MovementModule(mvmttreemodel, articulators, timingintervals, phonlocs, addedinfo, inphase)
-            unserialized[k].uniqueid = k
-        self.movementmodules = unserialized
-
     def serializelocationmodules(self):
         serialized = {}
         for k in self.locationmodules.keys():
             serialized[k] = LocationModuleSerializable(self.locationmodules[k])
         return serialized
 
-    def unserializelocationmodules(self, serialized_locnmodules):
-        unserialized = {}
-        for k in serialized_locnmodules.keys():
-            serialmodule = serialized_locnmodules[k]
-            articulators = serialmodule.articulators
-            timingintervals = serialmodule.timingintervals
-            addedinfo = serialmodule.addedinfo
-            phonlocs = serialmodule.phonlocs
-            inphase = serialmodule.inphase
-
-            serialtree = serialmodule.locationtree
-
-            # backward compatibility with corpora saved before Relation Module existed (June 2023)
-            # if hasattr(serialtree.locationtype, '_axis') and serialtree.locationtype.axis:
-            if serialtree.locationtype.allfalse() and "Horizontal" in serialtree.checkstates.keys() and "Vertical" in serialtree.checkstates.keys() and "Sagittal" in serialtree.checkstates.keys():
-                # then this likely was saved as an "axis of relation" location module, which is now
-                # deprecated and should be converted to a relation module
-
-                # relation module should have X = H1 and Y = H2
-                relation_x = RelationX(h1=True)
-                relation_y = RelationY(h2=True)
-                # relation module will have directions copied over from the original axis location tree
-                dir_hor = Direction(Direction.HORIZONTAL)
-                dir_ver = Direction(Direction.VERTICAL)
-                dir_sag = Direction(Direction.SAGITTAL)
-                for pathtext in serialtree.checkstates.keys():
-                    if serialtree.checkstates[pathtext] > 0:  # if fully or partially checked
-                        if "Horizontal" == pathtext:
-                            dir_hor.axisselected = True
-                        elif "Vertical" == pathtext:
-                            dir_ver.axisselected = True
-                        elif "Sagittal" == pathtext:
-                            dir_sag.axisselected = True
-                        elif "H1 is to H1 side of H2" in pathtext:
-                            dir_hor.plus = True
-                        elif "H1 is to H2 side of H2" in pathtext:
-                            dir_hor.minus = True
-                        elif "H1 is above H2" in pathtext:
-                            dir_ver.plus = True
-                        elif "H1 is below H2" in pathtext:
-                            dir_ver.minus = True
-                        elif "H1 is in front of H2" in pathtext or "H1 is more distal than H2" in pathtext:
-                            dir_sag.plus = True
-                        elif "H1 is behind H2" in pathtext or "H1 is more proximal than H2" in pathtext:
-                            dir_sag.minus = True
-                directions = [dir_hor, dir_ver, dir_sag]
-                bodyparts_dict = {
-                    HAND: {
-                        1: BodypartInfo(bodyparttype=HAND, bodyparttreemodel=BodypartTreeModel(bodyparttype=HAND)),
-                        2: BodypartInfo(bodyparttype=HAND, bodyparttreemodel=BodypartTreeModel(bodyparttype=HAND))
-                    },
-                    ARM: {
-                        1: BodypartInfo(bodyparttype=ARM, bodyparttreemodel=BodypartTreeModel(bodyparttype=ARM)),
-                        2: BodypartInfo(bodyparttype=ARM, bodyparttreemodel=BodypartTreeModel(bodyparttype=ARM))
-                    },
-                    LEG: {
-                        1: BodypartInfo(bodyparttype=LEG, bodyparttreemodel=BodypartTreeModel(bodyparttype=LEG)),
-                        2: BodypartInfo(bodyparttype=LEG, bodyparttreemodel=BodypartTreeModel(bodyparttype=LEG))
-                    }
-                }
-                # relation module should not have contact or manner or distance specified
-                convertedrelationmodule = RelationModule(relation_x, relation_y, bodyparts_dict=bodyparts_dict, contactrel=None, xy_crossed=False, xy_linked=False, directionslist=directions, articulators=None, timingintervals=timingintervals, phonlocs=phonlocs, addedinfo=addedinfo)
-                self.addmodule(convertedrelationmodule, ModuleTypes.RELATION)
-
-            else:
-                locntreemodel = LocationTreeModel(serialmodule.locationtree)
-                unserialized[k] = LocationModule(locntreemodel, articulators, timingintervals, phonlocs, addedinfo, inphase=inphase)
-                unserialized[k].uniqueid = k
-        self.locationmodules = unserialized
-
     def serializerelationmodules(self):
         serialized = {}
         for k in self.relationmodules.keys():
             serialized[k] = RelationModuleSerializable(self.relationmodules[k])
         return serialized
-
-    def unserializerelationmodules(self, serialized_relmodules):
-        unserialized = {}
-        for k in serialized_relmodules.keys():
-            serialmodule = serialized_relmodules[k]
-            articulators = serialmodule.articulators
-            timingintervals = serialmodule.timingintervals
-            addedinfo = serialmodule.addedinfo
-            phonlocs = serialmodule.phonlocs
-            relationx = serialmodule.relationx
-            relationy = serialmodule.relationy
-            bodyparts_dict = {
-                HAND: {
-                    1: BodypartInfo(
-                        bodyparttype=HAND,
-                        bodyparttreemodel=BodypartTreeModel(bodyparttype=HAND, serializedlocntree=serialmodule.bodyparts_dict[HAND][1].bodyparttree),
-                        addedinfo=serialmodule.bodyparts_dict[HAND][1].addedinfo),
-                    2: BodypartInfo(
-                        bodyparttype=HAND,
-                        bodyparttreemodel=BodypartTreeModel(bodyparttype=HAND, serializedlocntree=serialmodule.bodyparts_dict[HAND][2].bodyparttree),
-                        addedinfo=serialmodule.bodyparts_dict[HAND][2].addedinfo),
-                },
-                ARM: {
-                    1: BodypartInfo(
-                        bodyparttype=ARM,
-                        bodyparttreemodel=BodypartTreeModel(bodyparttype=ARM, serializedlocntree=serialmodule.bodyparts_dict[ARM][1].bodyparttree),
-                        addedinfo=serialmodule.bodyparts_dict[ARM][1].addedinfo),
-                    2: BodypartInfo(
-                        bodyparttype=ARM,
-                        bodyparttreemodel=BodypartTreeModel(bodyparttype=ARM, serializedlocntree=serialmodule.bodyparts_dict[ARM][2].bodyparttree),
-                        addedinfo=serialmodule.bodyparts_dict[ARM][2].addedinfo),
-                },
-                LEG: {
-                    1: BodypartInfo(
-                        bodyparttype=LEG,
-                        bodyparttreemodel=BodypartTreeModel(bodyparttype=LEG, serializedlocntree=serialmodule.bodyparts_dict[LEG][1].bodyparttree),
-                        addedinfo=serialmodule.bodyparts_dict[LEG][1].addedinfo),
-                    2: BodypartInfo(
-                        bodyparttype=LEG,
-                        bodyparttreemodel=BodypartTreeModel(bodyparttype=LEG, serializedlocntree=serialmodule.bodyparts_dict[LEG][2].bodyparttree),
-                        addedinfo=serialmodule.bodyparts_dict[LEG][2].addedinfo),
-                },
-            }
-            contactrel = serialmodule.contactrel
-            xy_crossed = serialmodule.xy_crossed
-            xy_linked = serialmodule.xy_linked
-            directions = serialmodule.directions
-
-            unserialized[k] = RelationModule(relationx, relationy, bodyparts_dict, contactrel,
-                                             xy_crossed, xy_linked, directionslist=directions,
-                                             articulators=articulators, timingintervals=timingintervals,
-                                             phonlocs=phonlocs, addedinfo=addedinfo)
-            unserialized[k].uniqueid = k
-        self.relationmodules = unserialized
 
     # technically this should not be implemented, because Sign objects are mutable
     # but a Corpus is implemented as a set of Sign objects, so we need a hash function
@@ -452,7 +315,8 @@ class Sign:
     def xslotstructure(self, xslotstruct):
         self._xslotstructure = xslotstruct
 
-    def updatemodule(self, existingkey, updated_module, moduletype):
+    def updatemodule(self, existingkey, updated_module):  # , moduletype):
+        moduletype = updated_module.moduletype
         current_module = self.getmoduledict(moduletype)[existingkey]
         ischanged = False
 
@@ -467,7 +331,13 @@ class Sign:
         if ischanged:
             self.lastmodifiednow()
 
-    def addmodule(self, module_to_add, moduletype):
+    # convenience function to avoid having to iterate over several calls to addmodule
+    def addmodules(self, modules_to_add):
+        for mod in modules_to_add:
+            self.addmodule(mod)
+
+    def addmodule(self, module_to_add):  # , moduletype):
+        moduletype = module_to_add.moduletype
         self.getmoduledict(moduletype)[module_to_add.uniqueid] = module_to_add
         self.getmodulenumbersdict(moduletype)[module_to_add.uniqueid] = self.getnextmodulenumber(moduletype)
         self.lastmodifiednow()
@@ -479,8 +349,12 @@ class Sign:
         return largestnum + 1
 
     def removemodule(self, uniqueid, moduletype):
-        self.getmoduledict(moduletype).pop(uniqueid)
-        self.removemodulenumber(uniqueid, moduletype)
+        if moduletype == ModuleTypes.SIGNTYPE:
+            # has no unique id (there's only ever one instance of a signtype module)
+            self.signtype = None
+        else:
+            self.getmoduledict(moduletype).pop(uniqueid)
+            self.removemodulenumber(uniqueid, moduletype)
         self.lastmodifiednow()
 
     def removemodulenumber(self, uniqueid, moduletype):
@@ -502,6 +376,150 @@ class Sign:
 
     def gettimedmodules(self):
         return [self.movementmodules, self.locationmodules, self.relationmodules, self.orientationmodules, self.handconfigmodules]
+
+
+def unserializemovementmodules(serialized_mvmtmodules):
+    unserialized = {}
+    for k in serialized_mvmtmodules.keys():
+        serialmodule = serialized_mvmtmodules[k]
+        mvmttreemodel = MovementTreeModel(serialmodule.movementtree)
+        articulators = serialmodule.articulators
+        inphase = serialmodule.inphase if (hasattr(serialmodule, 'inphase') and serialmodule.inphase is not None) else 0
+        timingintervals = serialmodule.timingintervals
+        addedinfo = serialmodule.addedinfo
+        phonlocs = serialmodule.phonlocs
+        unserialized[k] = MovementModule(mvmttreemodel, articulators, timingintervals, phonlocs, addedinfo, inphase)
+        unserialized[k].uniqueid = k
+    return unserialized
+
+
+def unserializelocationmodules(serialized_locnmodules):
+    unserialized = {}
+    convertedrelationmodules = []
+    for k in serialized_locnmodules.keys():
+        serialmodule = serialized_locnmodules[k]
+        articulators = serialmodule.articulators
+        timingintervals = serialmodule.timingintervals
+        addedinfo = serialmodule.addedinfo
+        phonlocs = serialmodule.phonlocs
+        inphase = serialmodule.inphase
+
+        serialtree = serialmodule.locationtree
+
+        # backward compatibility with corpora saved before Relation Module existed (June 2023)
+        # if hasattr(serialtree.locationtype, '_axis') and serialtree.locationtype.axis:
+        if serialtree.locationtype.allfalse() and "Horizontal" in serialtree.checkstates.keys() and "Vertical" in serialtree.checkstates.keys() and "Sagittal" in serialtree.checkstates.keys():
+            print("converting relation")
+            # then this likely was saved as an "axis of relation" location module, which is now
+            # deprecated and should be converted to a relation module
+
+            # relation module should have X = H1 and Y = H2
+            relation_x = RelationX(h1=True)
+            relation_y = RelationY(h2=True)
+            # relation module will have directions copied over from the original axis location tree
+            dir_hor = Direction(Direction.HORIZONTAL)
+            dir_ver = Direction(Direction.VERTICAL)
+            dir_sag = Direction(Direction.SAGITTAL)
+            for pathtext in serialtree.checkstates.keys():
+                if serialtree.checkstates[pathtext] > 0:  # if fully or partially checked
+                    if "Horizontal" == pathtext:
+                        dir_hor.axisselected = True
+                    elif "Vertical" == pathtext:
+                        dir_ver.axisselected = True
+                    elif "Sagittal" == pathtext:
+                        dir_sag.axisselected = True
+                    elif "H1 is to H1 side of H2" in pathtext:
+                        dir_hor.plus = True
+                    elif "H1 is to H2 side of H2" in pathtext:
+                        dir_hor.minus = True
+                    elif "H1 is above H2" in pathtext:
+                        dir_ver.plus = True
+                    elif "H1 is below H2" in pathtext:
+                        dir_ver.minus = True
+                    elif "H1 is in front of H2" in pathtext or "H1 is more distal than H2" in pathtext:
+                        dir_sag.plus = True
+                    elif "H1 is behind H2" in pathtext or "H1 is more proximal than H2" in pathtext:
+                        dir_sag.minus = True
+            directions = [dir_hor, dir_ver, dir_sag]
+            bodyparts_dict = {
+                HAND: {
+                    1: BodypartInfo(bodyparttype=HAND, bodyparttreemodel=BodypartTreeModel(bodyparttype=HAND)),
+                    2: BodypartInfo(bodyparttype=HAND, bodyparttreemodel=BodypartTreeModel(bodyparttype=HAND))
+                },
+                ARM: {
+                    1: BodypartInfo(bodyparttype=ARM, bodyparttreemodel=BodypartTreeModel(bodyparttype=ARM)),
+                    2: BodypartInfo(bodyparttype=ARM, bodyparttreemodel=BodypartTreeModel(bodyparttype=ARM))
+                },
+                LEG: {
+                    1: BodypartInfo(bodyparttype=LEG, bodyparttreemodel=BodypartTreeModel(bodyparttype=LEG)),
+                    2: BodypartInfo(bodyparttype=LEG, bodyparttreemodel=BodypartTreeModel(bodyparttype=LEG))
+                }
+            }
+            # relation module should not have contact or manner or distance specified
+            convertedrelationmodule = RelationModule(relation_x, relation_y, bodyparts_dict=bodyparts_dict, contactrel=None, xy_crossed=False, xy_linked=False, directionslist=directions, articulators=None, timingintervals=timingintervals, phonlocs=phonlocs, addedinfo=addedinfo)
+            convertedrelationmodules.append(convertedrelationmodule)
+            # self.addmodule(convertedrelationmodule)
+
+        else:
+            locntreemodel = LocationTreeModel(serialmodule.locationtree)
+            unserialized[k] = LocationModule(locntreemodel, articulators, timingintervals, phonlocs, addedinfo, inphase=inphase)
+            unserialized[k].uniqueid = k
+    return unserialized, convertedrelationmodules
+
+
+def unserializerelationmodules(serialized_relmodules):
+    unserialized = {}
+    for k in serialized_relmodules.keys():
+        serialmodule = serialized_relmodules[k]
+        articulators = serialmodule.articulators
+        timingintervals = serialmodule.timingintervals
+        addedinfo = serialmodule.addedinfo
+        phonlocs = serialmodule.phonlocs
+        relationx = serialmodule.relationx
+        relationy = serialmodule.relationy
+        bodyparts_dict = {
+            HAND: {
+                1: BodypartInfo(
+                    bodyparttype=HAND,
+                    bodyparttreemodel=BodypartTreeModel(bodyparttype=HAND, serializedlocntree=serialmodule.bodyparts_dict[HAND][1].bodyparttree),
+                    addedinfo=serialmodule.bodyparts_dict[HAND][1].addedinfo),
+                2: BodypartInfo(
+                    bodyparttype=HAND,
+                    bodyparttreemodel=BodypartTreeModel(bodyparttype=HAND, serializedlocntree=serialmodule.bodyparts_dict[HAND][2].bodyparttree),
+                    addedinfo=serialmodule.bodyparts_dict[HAND][2].addedinfo),
+            },
+            ARM: {
+                1: BodypartInfo(
+                    bodyparttype=ARM,
+                    bodyparttreemodel=BodypartTreeModel(bodyparttype=ARM, serializedlocntree=serialmodule.bodyparts_dict[ARM][1].bodyparttree),
+                    addedinfo=serialmodule.bodyparts_dict[ARM][1].addedinfo),
+                2: BodypartInfo(
+                    bodyparttype=ARM,
+                    bodyparttreemodel=BodypartTreeModel(bodyparttype=ARM, serializedlocntree=serialmodule.bodyparts_dict[ARM][2].bodyparttree),
+                    addedinfo=serialmodule.bodyparts_dict[ARM][2].addedinfo),
+            },
+            LEG: {
+                1: BodypartInfo(
+                    bodyparttype=LEG,
+                    bodyparttreemodel=BodypartTreeModel(bodyparttype=LEG, serializedlocntree=serialmodule.bodyparts_dict[LEG][1].bodyparttree),
+                    addedinfo=serialmodule.bodyparts_dict[LEG][1].addedinfo),
+                2: BodypartInfo(
+                    bodyparttype=LEG,
+                    bodyparttreemodel=BodypartTreeModel(bodyparttype=LEG, serializedlocntree=serialmodule.bodyparts_dict[LEG][2].bodyparttree),
+                    addedinfo=serialmodule.bodyparts_dict[LEG][2].addedinfo),
+            },
+        }
+        contactrel = serialmodule.contactrel
+        xy_crossed = serialmodule.xy_crossed
+        xy_linked = serialmodule.xy_linked
+        directions = serialmodule.directions
+
+        unserialized[k] = RelationModule(relationx, relationy, bodyparts_dict, contactrel,
+                                         xy_crossed, xy_linked, directionslist=directions,
+                                         articulators=articulators, timingintervals=timingintervals,
+                                         phonlocs=phonlocs, addedinfo=addedinfo)
+        unserialized[k].uniqueid = k
+    return unserialized
 
 
 class Corpus:

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -1158,6 +1158,14 @@ class Signtype:
         self._addedinfo = addedinfo if addedinfo is not None else AddedInfo()
         self._moduletype = ModuleTypes.SIGNTYPE
 
+    # == check compares all content (equality does not require references to be to the same spot in memory)
+    def __eq__(self, other):
+        if isinstance(other, Signtype):
+            self_attributes = self.__dict__
+            other_attributes = other.__dict__
+            return False not in [self_attributes[attr] == other_attributes[attr] for attr in self_attributes.keys()]
+        return False
+
     @property
     def moduletype(self):
         if not hasattr(self, '_moduletype'):

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -1283,7 +1283,7 @@ class BodypartInfo:
         return not self.__eq__(other)
 
     def getabbreviation(self):
-        # TODO KV implement
+        # TODO implement
         return "Bodypart abbreviations not yet implemented"
 
 
@@ -1642,7 +1642,7 @@ class RelationY:
 
     @linkedmoduletype.setter
     def linkedmoduletype(self, linkedmoduletype):
-        # TODO KV validate?
+        # TODO validate?
         self._linkedmoduletype = linkedmoduletype
 
     @property
@@ -1651,7 +1651,7 @@ class RelationY:
 
     @linkedmoduleids.setter
     def linkedmoduleids(self, linkedmoduleids):
-        # TODO KV validate?
+        # TODO validate?
         self._linkedmoduleids = linkedmoduleids
 
     @property
@@ -2492,4 +2492,14 @@ class XslotStructure:
     @additionalfraction.setter
     def additionalfraction(self, additionalfraction):
         self._additionalfraction = additionalfraction
+
+    def __eq__(self, other):
+        if isinstance(other, XslotStructure):
+            return self.number == other.number \
+                and self.additionalfraction == other.additionalfraction \
+                and set(self.fractionalpoints) == set(other.fractionalpoints)
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -111,7 +111,7 @@ def delay_uniqueid_reset(func):
 
 # TODO KV comments
 # TODO KV - for parameter modules and x-slots
-# common ancestor for (eg) HandshapeModule, MovementModule, etc
+# common ancestor for (eg) HandConfigurationModule, MovementModule, etc
 class ParameterModule:
 
     def __init__(self, articulators, timingintervals=None, phonlocs=None, addedinfo=None):

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -128,7 +128,6 @@ class ParameterModule:
     def moduletype(self):
         if not hasattr(self, '_moduletype'):
             # for backward compatibility with pre-20241018 parameter modules
-            print("moduletype backward compatibility")
             self._moduletype = ""
         return self._moduletype
 

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -135,7 +135,7 @@ class ParameterModule:
     @moduletype.setter
     def moduletype(self, moduletype):
         # validate the input string
-        if moduletype in ModuleTypes.abbreviations.keys():
+        if moduletype in ModuleTypes.parametertypes:
             self._moduletype = moduletype
 
     @property

--- a/src/main/python/lexicon/module_utils.py
+++ b/src/main/python/lexicon/module_utils.py
@@ -1,0 +1,31 @@
+from copy import deepcopy
+
+from lexicon.lexicon_classes import unserializemovementmodules, unserializelocationmodules, unserializerelationmodules
+from constant import ModuleTypes
+from serialization_classes import MovementModuleSerializable, LocationModuleSerializable, RelationModuleSerializable
+
+
+# module is either of type ParameterModule (or one of its children: MovementModule, OrientationModule, etc)
+#   OR of type SignType
+def deepcopymodule(module_orig):
+    moduletype = module_orig.moduletype
+    uid = module_orig.uniqueid
+    module_copy = None
+
+    if moduletype == ModuleTypes.MOVEMENT:
+        serialdict = {uid:MovementModuleSerializable(module_orig)}
+        module_copy = unserializemovementmodules(serialdict)[uid]
+    elif moduletype == ModuleTypes.LOCATION:
+        serialdict = {uid:LocationModuleSerializable(module_orig)}
+        locmods_copied, _ = unserializelocationmodules(serialdict)
+        module_copy = locmods_copied[uid]
+    elif moduletype == ModuleTypes.RELATION:
+        serialdict = {uid:RelationModuleSerializable(module_orig)}
+        module_copy = unserializerelationmodules(serialdict)[uid]
+    elif moduletype in [ModuleTypes.HANDCONFIG, ModuleTypes.ORIENTATION, ModuleTypes.NONMANUAL]:
+        module_copy = deepcopy(module_orig)
+
+    # create a new unique ID for the copied module
+    module_copy.uniqueid_reset()
+    return module_copy
+

--- a/src/main/python/lexicon/module_utils.py
+++ b/src/main/python/lexicon/module_utils.py
@@ -13,15 +13,15 @@ def deepcopymodule(module_orig):
     module_copy = None
 
     if moduletype == ModuleTypes.MOVEMENT:
-        serialdict = {uid:MovementModuleSerializable(module_orig)}
+        serialdict = {uid: MovementModuleSerializable(module_orig)}
         module_copy = unserializemovementmodules(serialdict)[uid]
     elif moduletype == ModuleTypes.LOCATION:
-        serialdict = {uid:LocationModuleSerializable(module_orig)}
+        serialdict = {uid: LocationModuleSerializable(module_orig)}
         locmods_copied, _ = unserializelocationmodules(serialdict)
         module_copy = locmods_copied[uid]
     elif moduletype == ModuleTypes.RELATION:
-        serialdict = {uid:RelationModuleSerializable(module_orig)}
-        module_copy = unserializerelationmodules(serialdict)[uid]
+        serialdict = {uid: RelationModuleSerializable(module_orig)}
+        module_copy = unserializerelationmodules(serialdict, makedeepcopy=True)[uid]
     elif moduletype in [ModuleTypes.HANDCONFIG, ModuleTypes.ORIENTATION, ModuleTypes.NONMANUAL]:
         module_copy = deepcopy(module_orig)
 

--- a/src/main/python/lexicon/module_utils.py
+++ b/src/main/python/lexicon/module_utils.py
@@ -1,12 +1,41 @@
 from copy import deepcopy
 
-from lexicon.lexicon_classes import unserializemovementmodules, unserializelocationmodules, unserializerelationmodules
+from lexicon.lexicon_classes import unserializemovementmodules, unserializelocationmodules, unserializerelationmodules, Sign, SignLevelInformation
 from constant import ModuleTypes
 from serialization_classes import MovementModuleSerializable, LocationModuleSerializable, RelationModuleSerializable
 
 
+def deepcopysignlevelinfo(sli_orig):
+    return SignLevelInformation(serializedsignlevelinfo=sli_orig.serialize(), parentsign=sli_orig.parentsign)
+
+
+def deepcopysign(sign_orig):
+    sign_copy = Sign()
+    sign_copy.signlevel_information = deepcopysignlevelinfo(sign_orig.signlevel_information)
+    sign_copy.signtype = deepcopy(sign_orig.signtype)
+    sign_copy.xslotstructure = deepcopy(sign_orig.xslotstructure)
+    sign_copy.specifiedxslots = deepcopy(sign_orig.specifiedxslots)
+
+    uid_updates = {}
+    # mtypes = ModuleTypes.parametertypes_relationfirst
+    for mtype in ModuleTypes.parametertypes_relationfirst:
+        for muid in sign_orig.getmoduledict(mtype).keys():
+            sign_copy.getmoduledict(mtype)[muid] = deepcopymodule(sign_orig.getmoduledict(mtype)[muid])
+            sign_copy.getmodulenumbersdict(mtype)[muid] = sign_orig.getmodulenumbersdict(mtype)[muid]
+        uid_updates[mtype] = sign_copy.reIDmodules(mtype)
+
+    # make sure any rel modules with associated mov or loc modules have their linked module IDs updated to the new version
+    for relmod in sign_copy.relationmodules.values():
+        if relmod.relationy.existingmodule:
+            linked_type = relmod.relationy.linkedmoduletype
+            if linked_type is not None:
+                orig_anchor_uids = relmod.relationy.linkedmoduleids
+                relmod.relationy.linkedmoduleids = [uid_updates[linked_type][a_uid] for a_uid in orig_anchor_uids]
+
+    return sign_copy
+
+
 # module is either of type ParameterModule (or one of its children: MovementModule, OrientationModule, etc)
-#   OR of type SignType
 def deepcopymodule(module_orig):
     moduletype = module_orig.moduletype
     uid = module_orig.uniqueid
@@ -21,7 +50,7 @@ def deepcopymodule(module_orig):
         module_copy = locmods_copied[uid]
     elif moduletype == ModuleTypes.RELATION:
         serialdict = {uid: RelationModuleSerializable(module_orig)}
-        module_copy = unserializerelationmodules(serialdict, makedeepcopy=True)[uid]
+        module_copy = unserializerelationmodules(serialdict)[uid]
     elif moduletype in [ModuleTypes.HANDCONFIG, ModuleTypes.ORIENTATION, ModuleTypes.NONMANUAL]:
         module_copy = deepcopy(module_orig)
 

--- a/src/main/python/models/location_models.py
+++ b/src/main/python/models/location_models.py
@@ -13,9 +13,9 @@ from PyQt5.Qt import (
 )
 import logging
 
-from lexicon.module_classes import LocationType, userdefinedroles as udr, treepathdelimiter, AddedInfo
+from lexicon.module_classes import LocationType, AddedInfo
 from serialization_classes import LocationTreeSerializable, LocationTableSerializable
-from constant import HAND, ARM, LEG, CONTRA, IPSI
+from constant import HAND, ARM, LEG, CONTRA, IPSI, userdefinedroles as udr, treepathdelimiter
 
 
 # radio button vs checkbox

--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -18,8 +18,8 @@ from PyQt5.QtWidgets import (
     QMessageBox
 )
 
-from lexicon.module_classes import userdefinedroles as udr, treepathdelimiter, AddedInfo
-from constant import CONTRA, IPSI
+from lexicon.module_classes import AddedInfo
+from constant import CONTRA, IPSI, userdefinedroles as udr, treepathdelimiter
 
 # for backwards compatibility
 specifytotalcycles_str = "Specify total number of cycles"

--- a/src/main/python/models/relation_models.py
+++ b/src/main/python/models/relation_models.py
@@ -11,21 +11,20 @@ from PyQt5.QtCore import (
 )
 
 from models.location_models import LocationTableModel, LocationTableSerializable, locn_options_hand, rb, ed, fx
-from lexicon.module_classes import AddedInfo, userdefinedroles as udr, ModuleTypes
-from constant import HAND, ARM, LEG, ARTICULATOR_ABBREVS
+from constant import HAND, ARM, LEG, ARTICULATOR_ABBREVS, ModuleTypes, userdefinedroles as udr
 
 
 class ModuleLinkingListModel(QStandardItemModel):
 
-    def __init__(self, modules=None, modulenumsdict=None, moduletype=None, **kwargs):
+    def __init__(self, modules=None, modulenumsdict=None, **kwargs):
         super().__init__(**kwargs)
-        self.setmoduleslist(modules, modulenumsdict, moduletype)
+        self.setmoduleslist(modules, modulenumsdict)
 
-    def setmoduleslist(self, modules=None, modulenumsdict=None, moduletype=None):
+    def setmoduleslist(self, modules=None, modulenumsdict=None):
         modules = modules or []
         self.clear()
         for idx, module in enumerate(modules):
-            moduleitem = ModuleLinkingListItem(module, modulenumsdict[module.uniqueid], moduletype)
+            moduleitem = ModuleLinkingListItem(module, modulenumsdict[module.uniqueid])
             self.appendRow(moduleitem)
         # self.modelupdated.emit()
         # self.dataChanged.emit()
@@ -48,12 +47,12 @@ class ModuleLinkingListModel(QStandardItemModel):
 
 class ModuleLinkingListItem(QStandardItem):
 
-    def __init__(self, module, modulenumber, moduletype):
+    def __init__(self, module, modulenumber):
         super().__init__()
 
         self.module = module
         self.modnum = modulenumber
-        self.moduletype = moduletype
+        self.moduletype = module.moduletype
         self.setEditable(False)
         self.setCheckable(False)
 

--- a/src/main/python/models/relation_models.py
+++ b/src/main/python/models/relation_models.py
@@ -1,17 +1,13 @@
-from copy import copy
-
 from PyQt5.Qt import (
     QStandardItem,
     QStandardItemModel
 )
 
 from PyQt5.QtCore import (
-    Qt,
-    QDateTime
+    Qt
 )
 
-from models.location_models import LocationTableModel, LocationTableSerializable, locn_options_hand, rb, ed, fx
-from constant import HAND, ARM, LEG, ARTICULATOR_ABBREVS, ModuleTypes, userdefinedroles as udr
+from constant import ARTICULATOR_ABBREVS, ModuleTypes
 
 
 class ModuleLinkingListModel(QStandardItemModel):

--- a/src/main/python/serialization_classes.py
+++ b/src/main/python/serialization_classes.py
@@ -7,9 +7,9 @@ from PyQt5.QtCore import (
     Qt
 )
 
-from lexicon.module_classes import PhonLocations, userdefinedroles as udr, AddedInfo
+from lexicon.module_classes import PhonLocations, AddedInfo
 from models.movement_models import fx
-from constant import HAND
+from constant import HAND, userdefinedroles as udr
 import logging
 
 class ParameterModuleSerializable:

--- a/src/main/python/serialization_classes.py
+++ b/src/main/python/serialization_classes.py
@@ -68,7 +68,6 @@ class LocationModuleSerializable(ParameterModuleSerializable):
 
         # creates a full serializable copy of the location module, eg for saving to disk
         self._inphase = locnmodule.inphase
-        self.phonlocs = locnmodule.phonlocs
         self.locationtree = LocationTreeSerializable(locnmodule.locationtreemodel)
 
     @property

--- a/src/main/python/serialization_classes.py
+++ b/src/main/python/serialization_classes.py
@@ -200,12 +200,6 @@ class LocationTreeSerializable:
                     self.addedinfos[pathtext] = copy(addedinfo)
                     self.detailstables[pathtext] = LocationTableSerializable(locntable)
                     self.checkstates[pathtext] = checkstate
-                    # editable = treechild.isEditable()  # TODO KV do this the same way as movement tree
-                    # if editable:
-                    #     pathsteps = pathtext.split(delimiter)
-                    #     parentpathtext = delimiter.join(pathsteps[:-1])
-                    #     numericstring = pathsteps[-1]  # pathtext[lastdelimindex + 1:]
-                    #     self.numvals[parentpathtext] = numericstring
                     iseditable = treechild.data(Qt.UserRole + udr.isuserspecifiablerole) != fx
                     userspecifiedvalue = treechild.data(Qt.UserRole + udr.userspecifiedvaluerole)
                     # if iseditable:


### PR DESCRIPTION
fixes #191  ... other than the "copy timing" part
- fixed an issue where copying/pasting a sign with linked modules didn't keep the linking between the modules
- fixed an issue where copying/pasting a sign with several of the same type of module didn't paste all instances
- anytime user copies/pastes module(s) without their associated modules, the user is invited to copy the associated one(s) too
- if user copies/pastes modules into a sign whose timing structure differs from the original, the user is warned to double-check timing for pasted module(s)
- if user pastes signtype in another sign with existing signtype, they are asked to confirm before overwriting
- user cannot paste modules into a sign whose x-slot info isn't set up yet (assuming x-slots are "on")
- user can right-click on module buttons *or* on visual summary background to access right-click menu with copy/paste/delete options
- keyboard shortcuts are active for copy/paste/delete, and *what* is copied/pasted/deleted depends on which panel has focus (ie corpus view for signs, vs visual summary for modules)



@kchall this pull request addresses a couple of little bugs I found in copy-sign behaviour, and fully implements copy-module behaviour. Would you like me to keep issue #191 open and move on to working on the copy-timing behaviour? Or write it off? Or just re-bundle it into a new issue and save it for later?
 - [ ] from 20241108 meeting: yes, implement copy-timing behaviour. have a hard restriction that you can't paste timing info into a module whose sign has different x-slot structure than the source