### PR TITLE
ensure "delete module(s)" menu item checks for selected modules to determine whether enabled

### DIFF
--- a/src/main/python/gui/xslot_graphics.py
+++ b/src/main/python/gui/xslot_graphics.py
@@ -351,7 +351,7 @@ class ModuleButtonContextMenu(QMenu):
 
         if "delete" in whichactions:
             self.delete_action = QAction("Delete module(s)")
-            self.delete_action.setEnabled(len(clipboardlist) > 0 and islistofmodules(clipboardlist))
+            self.delete_action.setEnabled(len(selected_modules) > 0 and islistofmodules(selected_modules))
             self.delete_action.triggered.connect(lambda checked: self.action_selected.emit("delete"))
             self.addAction(self.delete_action)
 


### PR DESCRIPTION
(as opposed to clipboard modules)