### PR TITLE
344 implement more efficient/intuitive shortcut for movement or location selection in movement or location dialog

### DIFF
--- a/src/main/python/gui/locationspecification_view.py
+++ b/src/main/python/gui/locationspecification_view.py
@@ -139,12 +139,7 @@ class LocationOptionsSelectionPanel(QFrame):
         #     # return true here to bypass default behaviour
         # return super().eventFilter(source, event)
 
-        if event.type() == QEvent.KeyPress:
-            key = event.key()
-            if key == Qt.Key_Enter:
-                print("enter pressed")
-            # TODO KV return true??
-        elif event.type() == QEvent.ContextMenu and source == self.pathslistview:
+        if event.type() == QEvent.ContextMenu and source == self.pathslistview:
             proxyindex = self.pathslistview.currentIndex()  # TODO what if multiple are selected?
             listindex = proxyindex.model().mapToSource(proxyindex)
             addedinfo = listindex.model().itemFromIndex(listindex).treeitem.addedinfo
@@ -187,6 +182,7 @@ class LocationOptionsSelectionPanel(QFrame):
         self.combobox.setModel(self.comboproxymodel)
         self.combobox.setCurrentIndex(-1)
         self.combobox.adjustSize()
+        self.combobox.setEnabled(False)
         self.combobox.item_selected.connect(self.selectlistitem)
         search_layout.addWidget(self.combobox)
 
@@ -668,12 +664,7 @@ class LocationSpecificationPanel(ModuleSpecificationPanel):
         #     # return true here to bypass default behaviour
         # return super().eventFilter(source, event)
 
-        if event.type() == QEvent.KeyPress:
-            key = event.key()
-            if key == Qt.Key_Enter:
-                print("enter pressed")
-            # TODO KV return true??
-        elif event.type() == QEvent.ContextMenu and source == self.pathslistview:
+        if event.type() == QEvent.ContextMenu and source == self.pathslistview:
             proxyindex = self.pathslistview.currentIndex()  # TODO KV what if multiple are selected?
             listindex = proxyindex.model().mapToSource(proxyindex)
             addedinfo = listindex.model().itemFromIndex(listindex).treeitem.addedinfo

--- a/src/main/python/gui/locationspecification_view.py
+++ b/src/main/python/gui/locationspecification_view.py
@@ -182,7 +182,6 @@ class LocationOptionsSelectionPanel(QFrame):
         self.combobox.setModel(self.comboproxymodel)
         self.combobox.setCurrentIndex(-1)
         self.combobox.adjustSize()
-        self.combobox.setEnabled(False)
         self.combobox.item_selected.connect(self.selectlistitem)
         search_layout.addWidget(self.combobox)
 

--- a/src/main/python/gui/locationspecification_view.py
+++ b/src/main/python/gui/locationspecification_view.py
@@ -13,9 +13,7 @@ from PyQt5.QtWidgets import (
     QGridLayout,
     QComboBox,
     QMessageBox,
-    QAbstractButton,
     QLabel,
-    QCompleter,
     QButtonGroup,
     QGroupBox,
     QAbstractItemView,
@@ -43,7 +41,8 @@ from PyQt5.QtCore import (
 
 from lexicon.module_classes import LocationModule
 from models.location_models import LocationTreeItem, LocationTableModel, LocationTreeModel, \
-    LocationType, LocationPathsProxyModel, locn_options_body
+    LocationType, locn_options_body
+from models.shared_models import TreePathsProxyModel
 from serialization_classes import LocationTreeSerializable, LocationTableSerializable
 from gui.modulespecification_widgets import AddedInfoContextMenu, ModuleSpecificationPanel, \
     TreeListView, TreePathsListItemDelegate, TreeSearchComboBox
@@ -81,9 +80,9 @@ class LocationOptionsSelectionPanel(QFrame):
 
         # create list proxies (for search and for selected options list)
         # and set them to refer to list model for current location type
-        self.comboproxymodel = LocationPathsProxyModel(wantselected=False)
+        self.comboproxymodel = TreePathsProxyModel(wantselected=False)
         self.comboproxymodel.setSourceModel(self.listmodel)
-        self.listproxymodel = LocationPathsProxyModel(wantselected=True)
+        self.listproxymodel = TreePathsProxyModel(wantselected=True)
         self.listproxymodel.setSourceModel(self.listmodel)
 
         # create layout with combobox for searching location items
@@ -173,7 +172,6 @@ class LocationOptionsSelectionPanel(QFrame):
         self._listmodel = listmodel
 
     def refresh_listproxies(self):
-
         self.comboproxymodel.setSourceModel(self.listmodel)
         self.listproxymodel.setSourceModel(self.listmodel)
         self.combobox.setModel(self.comboproxymodel)
@@ -189,12 +187,6 @@ class LocationOptionsSelectionPanel(QFrame):
         self.combobox.setModel(self.comboproxymodel)
         self.combobox.setCurrentIndex(-1)
         self.combobox.adjustSize()
-        self.combobox.setEditable(True)
-        self.combobox.setInsertPolicy(QComboBox.NoInsert)
-        self.combobox.setFocusPolicy(Qt.StrongFocus)
-        self.combobox.completer().setCaseSensitivity(Qt.CaseInsensitive)
-        self.combobox.completer().setFilterMode(Qt.MatchContains)
-        self.combobox.completer().setCompletionMode(QCompleter.PopupCompletion)
         self.combobox.item_selected.connect(self.selectlistitem)
         search_layout.addWidget(self.combobox)
 
@@ -208,9 +200,6 @@ class LocationOptionsSelectionPanel(QFrame):
             self.default_neutral_reqd.emit()
         if hasattr(self, "terminal_node_cb"):
             self.terminal_node_cb.setEnabled(True)
-        
-                    
-
 
     def create_selection_layout(self):
         selection_layout = QHBoxLayout()

--- a/src/main/python/gui/movementspecification_view.py
+++ b/src/main/python/gui/movementspecification_view.py
@@ -5,7 +5,6 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QComboBox,
     QLabel,
-    QCompleter,
     QAbstractItemView,
     QStyledItemDelegate,
     QStyle,
@@ -24,9 +23,11 @@ from PyQt5.QtCore import (
 )
 
 from lexicon.module_classes import MovementModule
-from models.movement_models import MovementTreeModel, MovementPathsProxyModel, MovementTreeItem
+from models.movement_models import MovementTreeModel, MovementTreeItem
+from models.shared_models import TreePathsProxyModel
 from serialization_classes import MovementTreeSerializable
-from gui.modulespecification_widgets import AddedInfoContextMenu, ModuleSpecificationPanel, TreeListView, TreePathsListItemDelegate, TreeSearchComboBox
+from gui.modulespecification_widgets import AddedInfoContextMenu, ModuleSpecificationPanel, TreeListView, \
+    TreePathsListItemDelegate, TreeSearchComboBox
 from constant import HAND, userdefinedroles as udr
 
 
@@ -82,7 +83,7 @@ class MvmtTreeItemDelegate(QStyledItemDelegate):
             style = widget.style() if widget else QApplication.style()
             opt = QStyleOptionViewItem(option)
             self.initStyleOption(opt, index)  
-            opt.features &= ~QStyleOptionViewItem.HasCheckIndicator # Turn off HasCheckIndicator
+            opt.features &= ~QStyleOptionViewItem.HasCheckIndicator  # Turn off HasCheckIndicator
             style.drawControl(QStyle.CE_ItemViewItem, opt, painter, widget)
         else:
             QStyledItemDelegate.paint(self, painter, option, index)
@@ -111,10 +112,10 @@ class MovementSpecificationPanel(ModuleSpecificationPanel):
 
         self.listmodel = self.treemodel.listmodel
 
-        self.comboproxymodel = MovementPathsProxyModel(wantselected=False)
+        self.comboproxymodel = TreePathsProxyModel(wantselected=False)
         self.comboproxymodel.setSourceModel(self.listmodel)
 
-        self.listproxymodel = MovementPathsProxyModel(wantselected=True)
+        self.listproxymodel = TreePathsProxyModel(wantselected=True)
         self.listproxymodel.setSourceModel(self.listmodel)
 
         # create layout with combobox for searching movement items
@@ -142,13 +143,7 @@ class MovementSpecificationPanel(ModuleSpecificationPanel):
         self.combobox.setModel(self.comboproxymodel)
         self.combobox.setCurrentIndex(-1)
         self.combobox.adjustSize()
-        self.combobox.setEditable(True)
-        self.combobox.setInsertPolicy(QComboBox.NoInsert)
-        self.combobox.setFocusPolicy(Qt.StrongFocus)
         self.combobox.setEnabled(True)
-        self.combobox.completer().setCaseSensitivity(Qt.CaseInsensitive)
-        self.combobox.completer().setFilterMode(Qt.MatchContains)
-        self.combobox.completer().setCompletionMode(QCompleter.PopupCompletion)
         self.combobox.item_selected.connect(self.selectlistitem)
         search_layout.addWidget(self.combobox)
 
@@ -280,8 +275,6 @@ class MovementSpecificationPanel(ModuleSpecificationPanel):
         self.pathslistview.setModel(self.listproxymodel)
 
         self.sortcombo.setCurrentIndex(0)  # change 'sort by' option to the first item of the list.
-
-        # self.combobox.clear()
 
     def clearlist(self, button):
         numtoplevelitems = self.treemodel.invisibleRootItem().rowCount()

--- a/src/main/python/gui/movementspecification_view.py
+++ b/src/main/python/gui/movementspecification_view.py
@@ -234,12 +234,7 @@ class MovementSpecificationPanel(ModuleSpecificationPanel):
         #     # return true here to bypass default behaviour
         # return super().eventFilter(source, event)
 
-        if event.type() == QEvent.KeyPress:
-            key = event.key()
-            if key == Qt.Key_Enter:
-                print("enter pressed")
-            # TODO KV return true??
-        elif event.type() == QEvent.ContextMenu and source == self.pathslistview:
+        if event.type() == QEvent.ContextMenu and source == self.pathslistview:
             proxyindex = self.pathslistview.currentIndex()  # TODO KV what if multiple are selected?
             # proxyindex = self.pathslistview.selectedIndexes()[0]
             listindex = proxyindex.model().mapToSource(proxyindex)

--- a/src/main/python/models/location_models.py
+++ b/src/main/python/models/location_models.py
@@ -16,6 +16,7 @@ import logging
 
 from lexicon.module_classes import LocationType, AddedInfo
 from serialization_classes import LocationTreeSerializable, LocationTableSerializable
+from models.shared_models import TreePathsProxyModel
 from constant import HAND, ARM, LEG, CONTRA, IPSI, userdefinedroles as udr, treepathdelimiter
 
 
@@ -752,8 +753,7 @@ class LocationTreeModel(QStandardItemModel):
             
             checked_values.extend(self.get_checked_items(index, only_fully_checked))
         return checked_values
-    
-    
+
     def updateCheckState(self, item):
         thestate = item.checkState()
         if thestate == Qt.Checked:
@@ -1076,38 +1076,6 @@ class LocationListItem(QStandardItem):
     def selectpath(self):
         self.treeitem.check(fully=True)
 
-
-class LocationPathsProxyModel(QSortFilterProxyModel):
-
-    def __init__(self, parent=None, wantselected=None):
-        super(LocationPathsProxyModel, self).__init__(parent)
-        self.wantselected = wantselected
-        self.setSortCaseSensitivity(Qt.CaseInsensitive)
-
-    def filterAcceptsRow(self, source_row, source_parent):
-        if self.wantselected is None:
-            source_index = self.sourceModel().index(source_row, 0, source_parent)
-            text = self.sourceModel().index(source_row, 0, source_parent).data()
-            return True
-        else:
-            source_index = self.sourceModel().index(source_row, 0, source_parent)
-            isselected = source_index.data(role=Qt.UserRole+udr.selectedrole)
-            path = source_index.data(role=Qt.UserRole+udr.pathdisplayrole)
-            text = self.sourceModel().index(source_row, 0, source_parent).data()
-            return self.wantselected == isselected
-
-    def updatesorttype(self, sortbytext=""):
-        if "alpha" in sortbytext and "path" in sortbytext:
-            self.setSortRole(Qt.DisplayRole)
-            self.sort(0)
-        elif "alpha" in sortbytext and "node" in sortbytext:
-            self.setSortRole(Qt.UserRole+udr.nodedisplayrole)
-            self.sort(0)
-        elif "tree" in sortbytext:
-            self.sort(-1)  # returns to sort order of underlying model
-        elif "select" in sortbytext:
-            self.setSortRole(Qt.UserRole+udr.timestamprole)
-            self.sort(0)
 
 class LocationTreeItem(QStandardItem):
 

--- a/src/main/python/models/movement_models.py
+++ b/src/main/python/models/movement_models.py
@@ -20,6 +20,7 @@ from PyQt5.QtWidgets import (
 )
 
 from lexicon.module_classes import AddedInfo
+from models.shared_models import TreePathsProxyModel
 from constant import CONTRA, IPSI, userdefinedroles as udr, treepathdelimiter
 
 # for backwards compatibility
@@ -1101,39 +1102,6 @@ class MovementListItem(QStandardItem):
 
     def selectpath(self):
         self.treeitem.check(fully=True)
-
-
-class MovementPathsProxyModel(QSortFilterProxyModel):
-
-    def __init__(self, parent=None, wantselected=None):
-        super(MovementPathsProxyModel, self).__init__(parent)
-        self.wantselected = wantselected
-        self.setSortCaseSensitivity(Qt.CaseInsensitive)
-
-    def filterAcceptsRow(self, source_row, source_parent):
-        if self.wantselected is None:
-            source_index = self.sourceModel().index(source_row, 0, source_parent)
-            text = self.sourceModel().index(source_row, 0, source_parent).data()
-            return True
-        else:
-            source_index = self.sourceModel().index(source_row, 0, source_parent)
-            isselected = source_index.data(role=Qt.UserRole+udr.selectedrole)
-            path = source_index.data(role=Qt.UserRole+udr.pathdisplayrole)
-            text = self.sourceModel().index(source_row, 0, source_parent).data()
-            return self.wantselected == isselected
-
-    def updatesorttype(self, sortbytext=""):
-        if "alpha" in sortbytext and "path" in sortbytext:
-            self.setSortRole(Qt.DisplayRole)
-            self.sort(0)
-        elif "alpha" in sortbytext and "node" in sortbytext:
-            self.setSortRole(Qt.UserRole+udr.nodedisplayrole)
-            self.sort(0)
-        elif "tree" in sortbytext:
-            self.sort(-1)  # returns to sort order of underlying model
-        elif "select" in sortbytext:
-            self.setSortRole(Qt.UserRole+udr.timestamprole)
-            self.sort(0)
 
 
 class MovementListModel(QStandardItemModel):

--- a/src/main/python/models/shared_models.py
+++ b/src/main/python/models/shared_models.py
@@ -1,0 +1,41 @@
+
+from PyQt5.QtCore import (
+    Qt,
+    QSortFilterProxyModel
+)
+
+from constant import userdefinedroles as udr
+
+
+# used by both Location and Movement to filter selected tree paths (for combobox and selected paths list)
+class TreePathsProxyModel(QSortFilterProxyModel):
+
+    def __init__(self, parent=None, wantselected=None):
+        super(TreePathsProxyModel, self).__init__(parent)
+        self.wantselected = wantselected
+        self.setSortCaseSensitivity(Qt.CaseInsensitive)
+
+    def filterAcceptsRow(self, source_row, source_parent):
+        if self.wantselected is None:
+            source_index = self.sourceModel().index(source_row, 0, source_parent)
+            text = self.sourceModel().index(source_row, 0, source_parent).data()
+            return True
+        else:
+            source_index = self.sourceModel().index(source_row, 0, source_parent)
+            isselected = source_index.data(role=Qt.UserRole+udr.selectedrole)
+            path = source_index.data(role=Qt.UserRole+udr.pathdisplayrole)
+            text = self.sourceModel().index(source_row, 0, source_parent).data()
+            return self.wantselected == isselected
+
+    def updatesorttype(self, sortbytext=""):
+        if "alpha" in sortbytext and "path" in sortbytext:
+            self.setSortRole(Qt.DisplayRole)
+            self.sort(0)
+        elif "alpha" in sortbytext and "node" in sortbytext:
+            self.setSortRole(Qt.UserRole+udr.nodedisplayrole)
+            self.sort(0)
+        elif "tree" in sortbytext:
+            self.sort(-1)  # returns to sort order of underlying model
+        elif "select" in sortbytext:
+            self.setSortRole(Qt.UserRole+udr.timestamprole)
+            self.sort(0)


### PR DESCRIPTION
In the search combobox that appears in both Movement and Location module dialogs, it is now the case that:
 1. choosing an item with the mouse OR by typing and pressing enter will add it to the selected list, without having to use the right arrow key
 2. whether you used the mouse or the keyboard, once the item has been selected the combobox text should be cleared so that the next item can immediately be searched for