### PR TITLE
166 abbreviations for location module

### DIFF
--- a/src/main/python/gui/locationspecification_view.py
+++ b/src/main/python/gui/locationspecification_view.py
@@ -654,6 +654,9 @@ class LocationSpecificationPanel(ModuleSpecificationPanel):
         self.locationoptionsselectionpanel.update_detailstable()
         self.locationoptionsselectionpanel.detailstableview.setEnabled(enabledetailstable)
 
+        self.locationoptionsselectionpanel.treemodel.defaultneutralselected = self.markneutral_cb.checkState()
+        
+
     def getsavedmodule(self, articulators, timingintervals, phonlocs, addedinfo, inphase):
         # phonlocs = self.getcurrentphonlocs()
         locmod = LocationModule(self.getcurrenttreemodel(),

--- a/src/main/python/gui/modulespecification_dialog.py
+++ b/src/main/python/gui/modulespecification_dialog.py
@@ -409,6 +409,7 @@ class ModuleSelectorDialog(QDialog):
             self.validate_and_save(addanother=False, closedialog=True)
 
         elif standard == QDialogButtonBox.RestoreDefaults:  # restore defaults
+            self.phonloc_selection.clear()
             if self.usearticulators:
                 self.articulators_widget.clear()
             self.addedinfobutton.clear()

--- a/src/main/python/gui/modulespecification_widgets.py
+++ b/src/main/python/gui/modulespecification_widgets.py
@@ -491,6 +491,15 @@ class PhonLocSelection(QWidget):
         )
         return phonlocs
 
+    def clear(self):
+        if (hasattr(self, "majorphonloc_cb") and hasattr(self, "minorphonloc_cb")):
+            self.majorphonloc_cb.setChecked(False)
+            self.minorphonloc_cb.setChecked(False)
+            self.majorphonloc_cb.setEnabled(False)
+            self.minorphonloc_cb.setEnabled(False)
+        self.phonological_cb.setChecked(False)
+        self.phonetic_cb.setChecked(False)
+
 
     def __init__(self, isLocationModule=False): 
         super().__init__() 

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -1923,6 +1923,7 @@ class RelationModule(ParameterModule):
 
     # relation abbreviation
     def getabbreviation(self):
+        phonphon_str = self.phonlocs.getabbreviation()
         X_str, Y_str = '', ''
         
         paths = self.get_paths() 
@@ -1997,7 +1998,7 @@ class RelationModule(ParameterModule):
             to_append.append(generic_dist_label)
             relative_label += f"X is {', '.join(filter(None, to_append))} to Y"
         
-        return "; ".join(filter(None, [X_str, Y_str, contact, link_cross_label, relative_label]))
+        return ": ".join(filter(None, [phonphon_str, "; ".join(filter(None, [X_str, Y_str, contact, link_cross_label, relative_label]))]))
     
 
 

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -15,7 +15,7 @@ PREDEFINED_MAP = {handshape.canonical: handshape for handshape in PREDEFINED_MAP
 
 def get_path_lowest_node(path):
     '''Return the lowest node of a path. 
-        e.g. 'Whole hand>Finger 1' returns 'Finger 1'
+        e.g. 'Whole hand>Finger 1' returns 'Finger 1'\n
             'Whole hand' returns 'Whole hand'
     '''
     return path.split(treepathdelimiter)[-1]
@@ -118,23 +118,25 @@ class ParameterModule:
 
     def get_art_abbrev(self): # articulator abbreviation
         todisplay = ""
+        # self.articulators is (Articulator, {1: bool, 2: bool})
         k = self.articulators[0] # hand, arm, or leg
-        if self.articulators[1][1] and not self.articulators[1][2]:
+        if self.articulators[1][1] and not self.articulators[1][2]: # articulator 1
             todisplay = k + " " + str(1)
-        elif self.articulators[1][2] and not self.articulators[1][1]:
+        elif self.articulators[1][2] and not self.articulators[1][1]: # articulator 2
             todisplay = k + " " + str(2)
-        # elif self.articulators[1][1] and self.articulators[1][2]:
-            
-        #     todisplay = "Both " + k.lower() + "s"
-        #     if self.inphase == 1:
-        #         todisplay += " in phase"
-        #     elif self.inphase == 2:
-        #         todisplay += " out of phase"
-        #     elif self.inphase == 3:
-        #         todisplay += " connected"
-        #     elif self.inphase == 4:
-        #         todisplay += " connected, in phase"
+        elif self.articulators[1][1] and self.articulators[1][2]: # both articulators
+            todisplay = "Both " + k.lower() + "s"
+            if self.inphase == 1:
+                todisplay += " in phase"
+            elif self.inphase == 2:
+                todisplay += " out of phase"
+            elif self.inphase == 3:
+                todisplay += " connected"
+            elif self.inphase == 4:
+                todisplay += " connected, in phase"
         return todisplay
+
+
 
     def getabbreviation(self):
         return "Module abbreviations not yet implemented"
@@ -617,6 +619,27 @@ class PhonLocations:
 
     def allfalse(self):
         return not (self._phoneticloc or self._phonologicalloc or self._majorphonloc or self._minorphonloc)
+    
+    def getabbreviation(self):
+        if self.allfalse():
+            return ""
+        to_return = []
+        if self.phonologicalloc:
+            if self.majorphonloc and not self.minorphonloc:
+                to_return.append("maj. phonol")
+            elif self.minorphonloc and not self.majorphonloc:
+                to_return.append("min. phonol")
+            else:
+                to_return.append("phonol")
+        if self.phoneticloc:
+            to_return.append("phonet")
+        if self.phonologicalloc and self.phoneticloc:
+            return (f"{to_return[0]} and {to_return[1]}").capitalize()
+        return to_return[0].capitalize()
+
+
+
+        
 
 
 # this class stores info about what kind of location type (body or signing space)
@@ -707,7 +730,19 @@ class LocationType:
         changed = changed or (previous.usesbodylocations() or previous.purelyspatial)
         changed = changed or (previous.allfalse() and not self.allfalse())
         return changed
-
+    
+    def getabbreviation(self):
+        if self.allfalse():
+            return ""
+        if self._body:
+            return "Body"
+        elif self._signingspace:
+            if self._bodyanchored:
+                return "Signing space(body-anch)"
+            elif self._purelyspatial:
+                return "Signing space(spatial)"
+            return "Signing space"
+        return "Other loctype"
 
 # Represents one specific point in time in an x-slot timing structure
 class TimingPoint:
@@ -1283,9 +1318,56 @@ class LocationModule(ParameterModule):
     @inphase.setter
     def inphase(self, inphase):
         self._inphase = inphase
+    
+
 
     def getabbreviation(self):
-        return "Location abbreviations not yet implemented"
+        phonphon_str = self.phonlocs.getabbreviation()
+        loctype_str = self.locationtreemodel.locationtype.getabbreviation()
+        is_neutral_str = "neutral" if self.locationtreemodel.defaultneutralselected else ""
+
+        path_strings = []
+
+        # purely spatial locations don't have surfaces / subareas; we handle the abbrev differently
+        if loctype_str == "Signing space(spatial)":
+            # setting only_fully_checked False returns each individual node in the path (eg 'Sagittal axis', 'Sagittal axis>In front)
+            # so that we can get the abbreviations of intermediate nodes
+            paths = self.locationtreemodel.get_checked_items(only_fully_checked=False, include_details=True) 
+            last_node = ""
+            curr_abbrev_list = []
+            # Each 'curr_node' is a dict. Keys are 'path', 'abbrev', 'details'
+            for curr_node in paths:
+                if curr_node['path'] == 'Default neutral space':
+                    is_neutral_str = "neutral"
+                else:
+                    curr_abbrev = (get_path_lowest_node(curr_node['path']) if curr_node['abbrev'] is None else curr_node['abbrev']).lower()
+                    if last_node in curr_node['path']:
+                        curr_abbrev_list.append(curr_abbrev)
+                    else:
+                        # append [ ] if axis / distance is not specified
+                        # eg hor[ipsi][ ]; ver[ ][ ]; sag[front][med] 
+                        path_strings.append(''.join(curr_abbrev_list) + ''.join(['[ ]' for _ in range(3 - len(curr_abbrev_list))]))
+                        curr_abbrev_list = [curr_node['abbrev']]  
+                    last_node = curr_node['path']
+            if len(curr_abbrev_list) > 0: # in case the list only contains Default neutral space
+                path_strings.append(''.join(curr_abbrev_list) + ''.join(['[ ]' for _ in range(3 - len(curr_abbrev_list))]))
+
+        else:
+            # each 'path' is a dict. Keys are 'path', 'abbrev', 'details'
+            for path in self.locationtreemodel.get_checked_items(include_details=True):
+                path_str = get_path_lowest_node(path['path']) if path['abbrev'] is None else path['abbrev']
+                # details_dict: keys are the subarea types ('surface', 'sub-area', or ''); 
+                # values are lists of checked subareas
+                details_dict = path['details'].get_checked_values()
+                # add surfaces and subareas in square brackets, eg [ant][centre]; if unspecified, leave square brackets with a space [ ]
+                for key, val in details_dict.items(): 
+                    if key:
+                        path_str += f'[{" " if len(val) == 0 else ", ".join([v if v not in SURFACE_SUBAREA_ABBREVS else SURFACE_SUBAREA_ABBREVS[v] for v in val])}]'
+                path_strings.append(path_str)
+        path_strings = '; '.join(filter(None, path_strings))
+        
+
+        return ': '.join(filter(None, [phonphon_str, loctype_str, is_neutral_str, path_strings]))
 
 
 class RelationX:
@@ -1733,6 +1815,17 @@ class RelationModule(ParameterModule):
         self._directions = directions
     
     def get_paths(self):
+        """
+        Returns a dict mapping articulators to their selected path details.
+
+        Returns:
+            dict:
+                - Keys (str): Articulators ('H1', 'H2', 'Arm1', 'Arm2', 'Leg1', 'Leg2').
+                - Values (list[dict]): Lists of dictionaries (output from treemodel.get_checked_items())
+                    - 'path': the full path
+                    - 'abbrev': The abbreviation. None if the path leaf should not be abbreviated
+                    - 'details': The details table.
+        """
         paths = {}
         arts, nums = self.get_articulators_in_use()
         for i in range(len(arts)):
@@ -1742,6 +1835,16 @@ class RelationModule(ParameterModule):
             paths.update({label + str(nums[i]) : treemodel.get_checked_items(include_details=True)})
         
         return paths
+    
+    def get_path_abbrev(self, paths, art): # abbreviation for paths and details tables
+        path_strings = []
+        for path in paths[art]:
+            path_str = get_path_lowest_node(path['path']) if path['abbrev'] is None else path['abbrev']
+            details_dict = path['details'].get_checked_values()
+            for val in details_dict.values(): # list of surfaces, list of subareas/handjoints
+                path_str += f'[{" " if len(val) == 0 else ", ".join([v if v not in SURFACE_SUBAREA_ABBREVS else SURFACE_SUBAREA_ABBREVS[v] for v in val])}]'
+            path_strings.append(path_str)
+        return f'{art}[{" " if len(path_strings) == 0 else ", ".join(path_strings)}]'
 
     def has_any_distance(self):
         for i in range(4):
@@ -1822,8 +1925,6 @@ class RelationModule(ParameterModule):
     def getabbreviation(self):
         X_str, Y_str = '', ''
         
-        # returns a dict. Keys are articulators: H1, H2, Arm1, Arm2, Leg1, Leg2. 
-        # Values are lists of dicts {'path' = path, 'abbrev' = abbrev,'details' = detailstable}
         paths = self.get_paths() 
 
         X_art = self.relationx.displaystr().capitalize()
@@ -1836,7 +1937,6 @@ class RelationModule(ParameterModule):
             X_str += self.get_path_abbrev(paths, X_art)
 
         if self.relationy.existingmodule:
-            # TODO
             Y_str = f'linked {self.relationy.linkedmoduletype} module'
         else:
             Y_art = self.relationy.displaystr().capitalize()
@@ -1900,15 +2000,6 @@ class RelationModule(ParameterModule):
         return "; ".join(filter(None, [X_str, Y_str, contact, link_cross_label, relative_label]))
     
 
-    def get_path_abbrev(self, paths, art): # abbreviation for paths and details tables
-        path_strings = []
-        for path in paths[art]:
-            path_str = get_path_lowest_node(path['path']) if path['abbrev'] is None else path['abbrev']
-            details_dict = path['details'].get_checked_values()
-            for val in details_dict.values(): # list of surfaces, list of subareas/handjoints
-                path_str += f'[{", ".join([v if v not in SURFACE_SUBAREA_ABBREVS else SURFACE_SUBAREA_ABBREVS[v] for v in val])}]'
-            path_strings.append(path_str)
-        return f'{art}[{", ".join(path_strings)}]'
 
 class MannerRelation:
     def __init__(self, holding=False, continuous=False, intermittent=False, any=False):

--- a/src/main/python/models/location_models.py
+++ b/src/main/python/models/location_models.py
@@ -78,42 +78,6 @@ dorsum = "Dorsum"
 blade = "Blade"
 
 
-
-SURFACE_SUBAREA_ABBREVS = {
-    anterior: '[ant]',
-    posterior: '[post]',
-    lateral: '[lat]',
-    medial: '[med]',
-    top: '[top]',
-    bottom: '[bottom]',
-    contra_half: '[contra]',
-    upper_half: '[upper]',
-    whole: '[whole]',
-    centre: '[centre]',
-    lower_half: '[lower]',
-    ipsi_half: '[ipsi]',
-    finger_side: '[finger side]',
-    wrist_side: '[wrist side]',
-    ulnar_side: '[ulnar side]',
-    radial_side: '[radial side]',
-    back: '[b]',
-    friction: '[fr]',
-    radial: '[r]',
-    ulnar: '[u]',
-    tip: '[t]',
-    front_half: '[ant]',
-    back_half: '[post]',
-    dorsum: '[dors]',
-    blade: '[blade]',
-    metacarpophalangeal_joint: '[MCP]',
-    proximal_interphalangeal_joint: '[PIP]',
-    distal_interphalangeal_joint: '[DIP]',
-    proximal_bone: '[p]',
-    medial_bone: '[m]',
-    distal_bone: '[d]'
-
-}
-
 hand_surfaces = "default hand surfaces" # [back, friction, radial, ulnar]
 nonhand_surfaces = "default nonhand surfaces" # [anterior, posterior, lateral, medial, top, bottom]
 nonhand_surfaces_2 = "default except top, bottom" # [anterior, posterior, lateral, medial]
@@ -564,8 +528,8 @@ locn_options_purelyspatial = LocnOptionsNode("purelyspatial_options_root", child
         LocnOptionsNode("Mid", fx, rb, tooltip="[mid]"),
         LocnOptionsNode("Low", fx, rb, tooltip="[low]"),
     ]),
-    LocnOptionsNode("Sagittal axis", fx, cb, "sag", children=[
-        LocnOptionsNode("In front", fx, rb, "[front]", children=[
+    LocnOptionsNode("Sagittal axis", fx, cb, tooltip="sag", children=[
+        LocnOptionsNode("In front", fx, rb, tooltip="[front]", children=[
             LocnOptionsNode("Far", fx, rb, tooltip="[far]"),
             LocnOptionsNode("Med.", fx, rb, tooltip="[med]"),
             LocnOptionsNode("Close", fx, rb, tooltip="[close]"),
@@ -777,11 +741,11 @@ class LocationTreeModel(QStandardItemModel):
         self._nodes_are_terminal = terminal    
 
     def get_checked_items(self, parent_index=QModelIndex(), only_fully_checked=True, include_details=False):
-        ''' Returns a list of strings denoting paths
+        ''' Returns: a list of strings denoting paths \n
             If include_details, returns a list of dicts: 
-            'path' = path,
-            'abbrev' = abbrev,
-            'details' = detailstable
+            - 'path': the full path
+            - 'abbrev': The abbreviation. None if the path leaf should not be abbreviated
+            - 'details': detailstable
             '''
         checked_values = []
         for row in range(self.rowCount(parent_index)):


### PR DESCRIPTION
* Implemented Location tooltips according to the [Abbreviations ](https://docs.google.com/spreadsheets/d/1qdf72ivD_tLFBvVQgSkzesyzVF_HWb1llmc2fmaqPI8/edit?gid=1251951879#gid=1251951879)sheet
* Fixed bug in ModuleSelectorDialog where the Restore Defaults button was not clearing phonological / phonetic checkboxes
* Fixed bug in Location Module where the `This location is neutral` cb checkstate was not being saved properly when switching between location types
* Tweaks to Relation tooltips:
  * Added a space in between square brackets to match the specification in the [Abbreviations ](https://docs.google.com/spreadsheets/d/1qdf72ivD_tLFBvVQgSkzesyzVF_HWb1llmc2fmaqPI8/edit?gid=1251951879#gid=1251951879)sheet:  `For surface/sub-area/joint/axis/distance info, leave an empty set of square brackets [ ] (with a space between them) if it's not specified`
  * Added phonological / phonetic info to tooltip