### PR TITLE
397 add several body part options to X and Y boxes in the relation module

### DIFF
--- a/src/main/python/gui/relationspecification_view.py
+++ b/src/main/python/gui/relationspecification_view.py
@@ -567,20 +567,24 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
 
     # enable the button for selecting handparts iff there is at least one hand selected in either X or Y
     def check_enable_handpartbutton(self):
-        h1_selected = self.x_h1_radio.isChecked() or self.x_both_radio.isChecked()
-        h2_selected = self.x_h2_radio.isChecked() or self.x_both_radio.isChecked() or self.y_h2_radio.isChecked()
+        h1_selected = self.x_h1_radio.isChecked() or self.x_hboth_radio.isChecked()
+        h2_selected = self.x_h2_radio.isChecked() or self.x_hboth_radio.isChecked() or self.y_h2_radio.isChecked()
         self.handpart_button.setEnabled(h1_selected or h2_selected)
 
     # enable the button for selecting armparts iff there is at least one arm selected in either X or Y
     def check_enable_armpartbutton(self):
-        a1_selected = self.x_a1_radio.isChecked()
-        a2_selected = self.x_a2_radio.isChecked() or self.y_a2_radio.isChecked()
+        a1_selected = self.x_a1_radio.isChecked() or self.x_aboth_radio.isChecked() or \
+                      self.y_a1_radio.isChecked() or self.y_aboth_radio.isChecked()
+        a2_selected = self.x_a2_radio.isChecked() or self.x_aboth_radio.isChecked() or \
+                      self.y_a2_radio.isChecked() or self.y_aboth_radio.isChecked()
         self.armpart_button.setEnabled(a1_selected or a2_selected)
 
     # enable the button for selecting legparts iff there is at least one leg selected in either X or Y
     def check_enable_legpartbutton(self):
-        l1_selected = self.x_l1_radio.isChecked() or self.y_l1_radio.isChecked()
-        l2_selected = self.x_l2_radio.isChecked() or self.y_l2_radio.isChecked()
+        l1_selected = self.x_l1_radio.isChecked() or self.x_lboth_radio.isChecked() or \
+                      self.y_l1_radio.isChecked() or self.y_lboth_radio.isChecked()
+        l2_selected = self.x_l2_radio.isChecked() or self.x_lboth_radio.isChecked() or \
+                      self.y_l2_radio.isChecked() or self.y_lboth_radio.isChecked()
         self.legpart_button.setEnabled(l1_selected or l2_selected)
 
     # prepare labels and open the dialog to select the handpart(s) involved in the relation
@@ -592,7 +596,7 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
             h1label = "X"
         elif self.x_h2_radio.isChecked():
             h2label = "X"
-        elif self.x_both_radio.isChecked():
+        elif self.x_hboth_radio.isChecked():
             h1label = "part of X"
             h2label = "part of X"
         if self.y_h2_radio.isChecked():
@@ -610,8 +614,16 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
             a1label = "X"
         elif self.x_a2_radio.isChecked():
             a2label = "X"
-        if self.y_a2_radio.isChecked():
+        elif self.x_aboth_radio.isChecked():
+            a1label = "part of X"
+            a2label = "part of X"
+        if self.y_a1_radio.isChecked():
+            a1label = "Y"
+        elif self.y_a2_radio.isChecked():
             a2label = "Y"
+        elif self.y_aboth_radio.isChecked():
+            a1label = "part of Y"
+            a2label = "part of Y"
         armpart_selector = BodypartSelectorDialog(bodyparttype=bodyparttype, bodypart1label=a1label, bodypart2label=a2label, bodypart1infotoload=self.bodyparts_dict[bodyparttype][1], bodypart2infotoload=self.bodyparts_dict[bodyparttype][2], forrelationmodule=True,parent=self)
         armpart_selector.bodyparts_saved.connect(lambda bodypart1, bodypart2: self.handle_bodyparts_saved(bodypart1, bodypart2, self.armpart_button))
         armpart_selector.exec_()
@@ -625,10 +637,16 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
             l1label = "X"
         elif self.x_l2_radio.isChecked():
             l2label = "X"
+        elif self.x_lboth_radio.isChecked():
+            l1label = "part of X"
+            l2label = "part of X"
         if self.y_l1_radio.isChecked():
             l1label = "Y"
         elif self.y_l2_radio.isChecked():
             l2label = "Y"
+        elif self.y_lboth_radio.isChecked():
+            l1label = "part of Y"
+            l2label = "part of Y"
         legpart_selector = BodypartSelectorDialog(bodyparttype=bodyparttype, bodypart1label=l1label, bodypart2label=l2label, bodypart1infotoload=self.bodyparts_dict[bodyparttype][1], bodypart2infotoload=self.bodyparts_dict[bodyparttype][2],  forrelationmodule=True, parent=self)
         legpart_selector.bodyparts_saved.connect(lambda bodypart1, bodypart2: self.handle_bodyparts_saved(bodypart1, bodypart2, self.legpart_button))
         legpart_selector.exec_()
@@ -647,40 +665,46 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         x_layout_right = QVBoxLayout()
         x_layout_leftandright = QHBoxLayout()
         x_other_layout = QHBoxLayout()
-        x_bothconnected_layout = QHBoxLayout()
+        x_hbothconnected_layout = QHBoxLayout()
         self.x_group = QButtonGroup()
         self.x_group.buttonToggled.connect(self.handle_xgroup_toggled)
         self.x_h1_radio = RelationRadioButton("H1")
         self.x_h2_radio = RelationRadioButton("H2")
-        self.x_both_radio = RelationRadioButton("Both hands")
-        self.x_bothconnected_cb = QCheckBox("As a connected unit")
-        self.x_bothconnected_cb.toggled.connect(self.handle_xconnected_toggled)
+        self.x_hboth_radio = RelationRadioButton("Both hands")
+        self.x_hbothconnected_cb = QCheckBox("As a connected unit")
+        self.x_hbothconnected_cb.toggled.connect(self.handle_xconnected_toggled)
         self.x_a1_radio = RelationRadioButton("Arm1")
         self.x_a2_radio = RelationRadioButton("Arm2")
+        self.x_aboth_radio = RelationRadioButton("Both arms")
         self.x_l1_radio = RelationRadioButton("Leg1")
         self.x_l2_radio = RelationRadioButton("Leg2")
+        self.x_lboth_radio = RelationRadioButton("Both legs")
         self.x_other_radio = RelationRadioButton("Other")
         self.x_other_text = QLineEdit()
         self.x_other_text.setPlaceholderText("Specify")
         self.x_other_text.textEdited.connect(lambda txt: self.handle_othertext_edited(txt, self.x_other_radio))
         self.x_group.addButton(self.x_h1_radio)
         self.x_group.addButton(self.x_h2_radio)
-        self.x_group.addButton(self.x_both_radio)
+        self.x_group.addButton(self.x_hboth_radio)
         self.x_group.addButton(self.x_a1_radio)
         self.x_group.addButton(self.x_a2_radio)
+        self.x_group.addButton(self.x_aboth_radio)
         self.x_group.addButton(self.x_l1_radio)
         self.x_group.addButton(self.x_l2_radio)
+        self.x_group.addButton(self.x_lboth_radio)
         self.x_group.addButton(self.x_other_radio)
         x_layout_left.addWidget(self.x_h1_radio)
         x_layout_left.addWidget(self.x_h2_radio)
-        x_layout_left.addWidget(self.x_both_radio)
-        x_bothconnected_layout.addSpacerItem(QSpacerItem(20, 0, QSizePolicy.Minimum, QSizePolicy.Maximum))
-        x_bothconnected_layout.addWidget(self.x_bothconnected_cb)
-        x_layout_left.addLayout(x_bothconnected_layout)
+        x_layout_left.addWidget(self.x_hboth_radio)
+        x_hbothconnected_layout.addSpacerItem(QSpacerItem(20, 0, QSizePolicy.Minimum, QSizePolicy.Maximum))
+        x_hbothconnected_layout.addWidget(self.x_hbothconnected_cb)
+        x_layout_left.addLayout(x_hbothconnected_layout)
         x_layout_right.addWidget(self.x_a1_radio)
         x_layout_right.addWidget(self.x_a2_radio)
+        x_layout_right.addWidget(self.x_aboth_radio)
         x_layout_right.addWidget(self.x_l1_radio)
         x_layout_right.addWidget(self.x_l2_radio)
+        x_layout_right.addWidget(self.x_lboth_radio)
         x_other_layout.addWidget(self.x_other_radio)
         x_other_layout.addWidget(self.x_other_text)
         x_layout_leftandright.addLayout(x_layout_left)
@@ -695,7 +719,7 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         selectedbutton = self.x_group.checkedButton()
 
         # enable "as a connected unit" iff the checked button is "both hands"
-        self.x_bothconnected_cb.setEnabled(selectedbutton == self.x_both_radio)
+        self.x_hbothconnected_cb.setEnabled(selectedbutton == self.x_hboth_radio)
 
         # enable "specify" text box iff the checked button is "other"
         self.x_other_text.setEnabled(selectedbutton == self.x_other_radio)
@@ -732,7 +756,7 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
             return
 
         # ensure the parent is checked
-        self.x_both_radio.setChecked(True)
+        self.x_hboth_radio.setChecked(True)
 
     # if user specifies text for an "other" selection, ensure the parent ("other") radio button is checked
     def handle_othertext_edited(self, txt, parentradiobutton):
@@ -757,9 +781,12 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         self.y_group = QButtonGroup()
         self.y_group.buttonToggled.connect(self.handle_ygroup_toggled)
         self.y_h2_radio = RelationRadioButton("H2")
+        self.y_a1_radio = RelationRadioButton("Arm1")
         self.y_a2_radio = RelationRadioButton("Arm2")
+        self.y_aboth_radio = RelationRadioButton("Both arms")
         self.y_l1_radio = RelationRadioButton("Leg1")
         self.y_l2_radio = RelationRadioButton("Leg2")
+        self.y_lboth_radio = RelationRadioButton("Both legs")
         self.y_existingmod_radio = RelationRadioButton("Existing module:")
         self.y_existingmod_switch = OptionSwitch("Location", "Movement")
 
@@ -768,18 +795,24 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         self.y_other_text.setPlaceholderText("Specify")
         self.y_other_text.textEdited.connect(lambda txt: self.handle_othertext_edited(txt, self.y_other_radio))
         self.y_group.addButton(self.y_h2_radio)
+        self.y_group.addButton(self.y_a1_radio)
         self.y_group.addButton(self.y_a2_radio)
+        self.y_group.addButton(self.y_aboth_radio)
         self.y_group.addButton(self.y_l1_radio)
         self.y_group.addButton(self.y_l2_radio)
+        self.y_group.addButton(self.y_lboth_radio)
         self.y_group.addButton(self.y_existingmod_radio)
         self.y_group.addButton(self.y_other_radio)
 
         self.create_linked_module_box()
 
         y_layout_left.addWidget(self.y_h2_radio)
+        y_layout_left.addWidget(self.y_a1_radio)
         y_layout_left.addWidget(self.y_a2_radio)
+        y_layout_left.addWidget(self.y_aboth_radio)
         y_layout_left.addWidget(self.y_l1_radio)
         y_layout_left.addWidget(self.y_l2_radio)
+        y_layout_left.addWidget(self.y_lboth_radio)
         y_existingmodule_layout.addWidget(self.y_existingmod_radio)
         y_existingmodule_layout.addWidget(self.y_existingmod_switch)
         y_existingmodule_layout.addStretch()
@@ -859,20 +892,24 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
             articulator, articulator_dict = linkedfrommodule.articulators
             if articulator == HAND:
                 if articulator_dict[1] and articulator_dict[2]:
-                    self.x_both_radio.setChecked(True)
+                    self.x_hboth_radio.setChecked(True)
                     if linkedfrommodule.inphase >= 3:
-                        self.x_bothconnected_cb.setChecked(True)
+                        self.x_hbothconnected_cb.setChecked(True)
                 elif articulator_dict[1]:
                     self.x_h1_radio.setChecked(True)
                 elif articulator_dict[2]:
                     self.x_h2_radio.setChecked(True)
             elif articulator == ARM:
-                if articulator_dict[1]:
+                if articulator_dict[1] and articulator_dict[2]:
+                    self.x_aboth_radio.setChecked(True)
+                elif articulator_dict[1]:
                     self.x_a1_radio.setChecked(True)
                 elif articulator_dict[2]:
                     self.x_a2_radio.setChecked(True)
             elif articulator == LEG:
-                if articulator_dict[1]:
+                if articulator_dict[1] and articulator_dict[2]:
+                    self.x_lboth_radio.setChecked(True)
+                elif articulator_dict[1]:
                     self.x_l1_radio.setChecked(True)
                 elif articulator_dict[2]:
                     self.x_l2_radio.setChecked(True)
@@ -916,25 +953,29 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
             self.x_other_text.setText(relationx.othertext)
             self.x_h1_radio.setChecked(relationx.h1)
             self.x_h2_radio.setChecked(relationx.h2)
-            self.x_both_radio.setChecked(relationx.both)
-            if relationx.both:
-                self.x_bothconnected_cb.setChecked(relationx.connected)
+            self.x_hboth_radio.setChecked(relationx.hboth)
+            if relationx.hboth:
+                self.x_hbothconnected_cb.setChecked(relationx.connected)
             self.x_a1_radio.setChecked(relationx.arm1)
             self.x_a2_radio.setChecked(relationx.arm2)
+            self.x_aboth_radio.setChecked(relationx.aboth)
             self.x_l1_radio.setChecked(relationx.leg1)
             self.x_l2_radio.setChecked(relationx.leg2)
+            self.x_lboth_radio.setChecked(relationx.lboth)
             self.x_other_radio.setChecked(relationx.other)
 
     # return the current X element specification as per the GUI values
     def getcurrentx(self):
         return RelationX(h1=self.x_h1_radio.isChecked(),
                          h2=self.x_h2_radio.isChecked(),
-                         both=self.x_both_radio.isChecked(),
-                         connected=self.x_bothconnected_cb.isChecked(),
+                         handboth=self.x_hboth_radio.isChecked(),
+                         connected=self.x_hbothconnected_cb.isChecked(),
                          arm1=self.x_a1_radio.isChecked(),
                          arm2=self.x_a2_radio.isChecked(),
+                         armboth=self.x_aboth_radio.isChecked(),
                          leg1=self.x_l1_radio.isChecked(),
                          leg2=self.x_l2_radio.isChecked(),
+                         legboth=self.x_lboth_radio.isChecked(),
                          other=self.x_other_radio.isChecked(),
                          othertext=self.x_other_text.text())
 
@@ -943,9 +984,12 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         if relationy is not None:
             self.y_other_text.setText(relationy.othertext)
             self.y_h2_radio.setChecked(relationy.h2)
+            self.y_a1_radio.setChecked(relationy.arm1)
             self.y_a2_radio.setChecked(relationy.arm2)
+            self.y_aboth_radio.setChecked(relationy.aboth)
             self.y_l1_radio.setChecked(relationy.leg1)
             self.y_l2_radio.setChecked(relationy.leg2)
+            self.y_lboth_radio.setChecked(relationy.lboth)
             self.y_existingmod_radio.setChecked(relationy.existingmodule)
             if relationy.existingmodule:
                 self.setcurrentlinkedmoduleinfo(relationy.linkedmoduleids, relationy.linkedmoduletype)
@@ -954,9 +998,12 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
     # return the current Y element specification as per the GUI values
     def getcurrenty(self):
         return RelationY(h2=self.y_h2_radio.isChecked(),
+                         arm1=self.y_a1_radio.isChecked(),
                          arm2=self.y_a2_radio.isChecked(),
+                         armboth=self.y_aboth_radio.isChecked(),
                          leg1=self.y_l1_radio.isChecked(),
                          leg2=self.y_l2_radio.isChecked(),
+                         legboth=self.y_lboth_radio.isChecked(),
                          existingmodule=self.y_existingmod_radio.isChecked(),
                          linkedmoduletype=self.getcurrentlinkedmoduletype(),
                          linkedmoduleids=self.getcurrentlinkedmoduleids(),
@@ -1184,14 +1231,14 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
     def clear_x_options(self):
         self.clear_group_buttons(self.x_group)
         self.x_other_text.clear()
-        self.x_bothconnected_cb.setChecked(False)
+        self.x_hbothconnected_cb.setChecked(False)
 
         self.enable_x_options(True)
 
     # enable all GUI elements for X selection
     def enable_x_options(self, doenable):
         self.x_other_text.setEnabled(doenable)
-        self.x_bothconnected_cb.setEnabled(doenable)
+        self.x_hbothconnected_cb.setEnabled(doenable)
 
     # clear and enable all GUI elements for Y selection
     def clear_y_options(self):

--- a/src/main/python/gui/relationspecification_view.py
+++ b/src/main/python/gui/relationspecification_view.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QSpacerItem,
     QSizePolicy,
+    QMessageBox,
 )
 
 from PyQt5.QtCore import (
@@ -590,6 +591,14 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
     # prepare labels and open the dialog to select the handpart(s) involved in the relation
     def handle_handpartbutton_clicked(self):
         bodyparttype = HAND
+        # h1conflict = not possible because Y only has h2 as a hand option
+        h2conflict = (self.x_h2_radio.isChecked() or self.x_hboth_radio.isChecked()) and self.y_h2_radio.isChecked()
+
+        if h2conflict:
+            # refuse to open the hand part specification if there is a conflict in X vs Y hand selections
+            QMessageBox.critical(self, "Warning", "X and Y overlap in hand selection. Ensure that X and Y selections are mutually exclusive before attempting to specify hand parts.")
+            return
+
         h1label = ""
         h2label = ""
         if self.x_h1_radio.isChecked():
@@ -608,6 +617,16 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
     # prepare labels and open the dialog to select the armpart(s) involved in the relation
     def handle_armpartbutton_clicked(self):
         bodyparttype = ARM
+        a1conflict = (self.x_a1_radio.isChecked() or self.x_aboth_radio.isChecked()) and \
+                     (self.y_a1_radio.isChecked() or self.y_aboth_radio.isChecked())
+        a2conflict = (self.x_a2_radio.isChecked() or self.x_aboth_radio.isChecked()) and \
+                     (self.y_a2_radio.isChecked() or self.y_aboth_radio.isChecked())
+
+        if a1conflict or a2conflict:
+            # refuse to open the arm part specification if there is a conflict in X vs Y arm selections
+            QMessageBox.critical(self, "Warning", "X and Y overlap in arm selection. Ensure that X and Y selections are mutually exclusive before attempting to specify arm parts.")
+            return
+
         a1label = ""
         a2label = ""
         if self.x_a1_radio.isChecked():
@@ -631,6 +650,16 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
     # prepare labels and open the dialog to select the legpart(s) involved in the relation
     def handle_legpartbutton_clicked(self):
         bodyparttype = LEG
+        l1conflict = (self.x_l1_radio.isChecked() or self.x_lboth_radio.isChecked()) and \
+                     (self.y_l1_radio.isChecked() or self.y_lboth_radio.isChecked())
+        l2conflict = (self.x_l2_radio.isChecked() or self.x_lboth_radio.isChecked()) and \
+                     (self.y_l2_radio.isChecked() or self.y_lboth_radio.isChecked())
+
+        if l1conflict or l2conflict:
+            # refuse to open the leg part specification if there is a conflict in X vs Y leg selections
+            QMessageBox.critical(self, "Warning", "X and Y overlap in leg selection. Ensure that X and Y selections are mutually exclusive before attempting to specify leg parts.")
+            return
+
         l1label = ""
         l2label = ""
         if self.x_l1_radio.isChecked():

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -1850,7 +1850,7 @@ class RelationModule(ParameterModule):
         paths = self.get_paths() 
 
         X_art = self.relationx.displaystr().capitalize()
-        if X_art.startswith("Both"):
+        if "both" in X_art.lower():
             art1, art2 = ('H1', 'H2') if "hands" in X_art else (('Arm1', 'Arm2') if "arms" in X_art else ('Leg1', 'Leg2'))
             X_str += f'{X_art}: '
             X_str += ', '.join([self.get_path_abbrev(paths, a) for a in [art1, art2]])
@@ -1864,7 +1864,7 @@ class RelationModule(ParameterModule):
             Y_str = f'linked {self.relationy.linkedmoduletype} module'
         else:
             Y_art = self.relationy.displaystr().capitalize()
-            if Y_art.startswith("Both"):
+            if "both" in Y_art.lower():
                 art1, art2 = ('H1', 'H2') if "hands" in Y_art else (('Arm1', 'Arm2') if "arms" in Y_art else ('Leg1', 'Leg2'))
                 Y_str += f'{Y_art}: '
                 Y_str += ', '.join([self.get_path_abbrev(paths, a) for a in [art1, art2]])

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -1264,15 +1264,17 @@ class LocationModule(ParameterModule):
 
 class RelationX:
 
-    def __init__(self, h1=False, h2=False, both=False, connected=False, arm1=False, arm2=False, leg1=False, leg2=False, other=False, othertext=""):
+    def __init__(self, h1=False, h2=False, handboth=False, connected=False, arm1=False, arm2=False, armboth=False, leg1=False, leg2=False, legboth=False, other=False, othertext=""):
         self._h1 = h1
         self._h2 = h2
-        self._both = both
+        self._hboth = handboth  # changed 20250220 - used to be self._both
         self._connected = connected
         self._arm1 = arm1
         self._arm2 = arm2
+        self._aboth = armboth  # added 20250220
         self._leg1 = leg1
         self._leg2 = leg2
+        self._lboth = legboth  # added 20250220
         self._other = other
         self._othertext = othertext
 
@@ -1308,16 +1310,9 @@ class RelationX:
 
     @h1.setter
     def h1(self, h1):
-        self._h1 = h1
-
         if h1:
-            self._h2 = False
-            self._both = False
-            self._arm1 = False
-            self._arm2 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._other = False
+            self.resetalltoplevelbooleans()
+            self._h1 = h1
 
     @property
     def h2(self):
@@ -1325,33 +1320,22 @@ class RelationX:
 
     @h2.setter
     def h2(self, h2):
-        self._h2 = h2
-
         if h2:
-            self._h1 = False
-            self._arm1 = False
-            self._arm2 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._both = False
-            self._other = False
+            self.resetalltoplevelbooleans()
+            self._h2 = h2
 
     @property
-    def both(self):
-        return self._both
+    def hboth(self):
+        if not hasattr(self, '_hboth'):
+            # backward compatibility for attribute changed 20250220
+            self._hboth = self._both if hasattr(self, '_both') else False
+        return self._hboth
 
-    @both.setter
-    def both(self, both):
-        self._both = both
-
-        if both:
-            self._h1 = False
-            self._h2 = False
-            self._arm1 = False
-            self._arm2 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._other = False
+    @hboth.setter
+    def hboth(self, hboth):
+        if hboth:
+            self.resetalltoplevelbooleans()
+            self._hboth = hboth
 
     @property
     def connected(self):
@@ -1362,7 +1346,7 @@ class RelationX:
         self._connected = connected
 
         if connected:
-            self.both = True
+            self.hboth = True
 
     @property
     def arm1(self):
@@ -1370,16 +1354,9 @@ class RelationX:
 
     @arm1.setter
     def arm1(self, arm1):
-        self._arm1 = arm1
-
         if arm1:
-            self._h1 = False
-            self._h2 = False
-            self._both = False
-            self._arm2 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._other = False
+            self.resetalltoplevelbooleans()
+            self._arm1 = arm1
 
     @property
     def arm2(self):
@@ -1387,16 +1364,22 @@ class RelationX:
 
     @arm2.setter
     def arm2(self, arm2):
-        self._arm2 = arm2
-
         if arm2:
-            self._h1 = False
-            self._h2 = False
-            self._both = False
-            self._arm1 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._other = False
+            self.resetalltoplevelbooleans()
+            self._arm2 = arm2
+
+    @property
+    def aboth(self):
+        if not hasattr(self, '_aboth'):
+            # backward compatibility for attribute added 20250220
+            self._aboth = False
+        return self._aboth
+
+    @aboth.setter
+    def aboth(self, aboth):
+        if aboth:
+            self.resetalltoplevelbooleans()
+            self._aboth = aboth
 
     @property
     def leg1(self):
@@ -1404,16 +1387,9 @@ class RelationX:
 
     @leg1.setter
     def leg1(self, leg1):
-        self._leg1 = leg1
-
         if leg1:
-            self._h1 = False
-            self._h2 = False
-            self._both = False
-            self._arm1 = False
-            self._arm2 = False
-            self._leg2 = False
-            self._other = False
+            self.resetalltoplevelbooleans()
+            self._leg1 = leg1
 
     @property
     def leg2(self):
@@ -1421,16 +1397,22 @@ class RelationX:
 
     @leg2.setter
     def leg2(self, leg2):
-        self._leg2 = leg2
-
         if leg2:
-            self._h1 = False
-            self._h2 = False
-            self._both = False
-            self._arm1 = False
-            self._arm2 = False
-            self._leg1 = False
-            self._other = False
+            self.resetalltoplevelbooleans()
+            self._leg2 = leg2
+
+    @property
+    def lboth(self):
+        if not hasattr(self, '_lboth'):
+            # backward compatibility for attribute added 20250220
+            self._lboth = False
+        return self._lboth
+
+    @lboth.setter
+    def lboth(self, lboth):
+        if lboth:
+            self.resetalltoplevelbooleans()
+            self._lboth = lboth
 
     @property
     def other(self):
@@ -1438,16 +1420,9 @@ class RelationX:
 
     @other.setter
     def other(self, other):
-        self._other = other
-
         if other:
-            self._h1 = False
-            self._h2 = False
-            self._both = False
-            self._arm1 = False
-            self._arm2 = False
-            self._leg1 = False
-            self._leg2 = False
+            self.resetalltoplevelbooleans()
+            self._other = other
 
     @property
     def othertext(self):
@@ -1457,13 +1432,29 @@ class RelationX:
     def othertext(self, othertext):
         self._othertext = othertext
 
+    # helper function for all setters, that resets all (main) boolean attributes to False
+    def resetalltoplevelbooleans(self):
+        self._h1 = False
+        self._h2 = False
+        self._hboth = False  # TODO KV changed
+        self._arm1 = False
+        self._arm2 = False
+        self._aboth = False  # TODO KV added
+        self._leg1 = False
+        self._leg2 = False
+        self._lboth = False  # TODO KV added
+        self._other = False
+
 class RelationY:
 
-    def __init__(self, h2=False, arm2=False, leg1=False, leg2=False, existingmodule=False, linkedmoduletype=None, linkedmoduleids=None, other=False, othertext=""):
+    def __init__(self, h2=False, arm1=False, arm2=False, armboth=False, leg1=False, leg2=False, legboth=False, existingmodule=False, linkedmoduletype=None, linkedmoduleids=None, other=False, othertext=""):
         self._h2 = h2
+        self._arm1 = arm1
         self._arm2 = arm2
+        self._aboth = armboth
         self._leg1 = leg1
         self._leg2 = leg2
+        self._lboth = legboth
         self._existingmodule = existingmodule
         self._linkedmoduletype = linkedmoduletype
         self._linkedmoduleids = linkedmoduleids or [0.0]
@@ -1507,14 +1498,22 @@ class RelationY:
 
     @h2.setter
     def h2(self, h2):
-        self._h2 = h2
-
         if h2:
-            self._arm2 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._existingmodule = False
-            self._other = False
+            self.resetallbooleans()
+            self._h2 = h2
+
+    @property
+    def arm1(self):
+        if not hasattr(self, '_arm1'):
+            # backward compatibility for attribute added 20250220
+            self._arm1 = False
+        return self._arm1
+
+    @arm1.setter
+    def arm1(self, arm1):
+        if arm1:
+            self.resetallbooleans()
+            self._arm1 = arm1
 
     @property
     def arm2(self):
@@ -1522,14 +1521,22 @@ class RelationY:
 
     @arm2.setter
     def arm2(self, arm2):
-        self._arm2 = arm2
-
         if arm2:
-            self._h2 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._existingmodule = False
-            self._other = False
+            self.resetallbooleans()
+            self._arm2 = arm2
+
+    @property
+    def aboth(self):
+        if not hasattr(self, '_aboth'):
+            # backward compatibility for attribute added 20250220
+            self._aboth = False
+        return self._aboth
+
+    @aboth.setter
+    def aboth(self, aboth):
+        if aboth:
+            self.resetallbooleans()
+            self._aboth = aboth
 
     @property
     def leg1(self):
@@ -1537,14 +1544,9 @@ class RelationY:
 
     @leg1.setter
     def leg1(self, leg1):
-        self._leg1 = leg1
-
         if leg1:
-            self._h2 = False
-            self._arm2 = False
-            self._leg2 = False
-            self._existingmodule = False
-            self._other = False
+            self.resetallbooleans()
+            self._leg1 = leg1
 
     @property
     def leg2(self):
@@ -1552,14 +1554,22 @@ class RelationY:
 
     @leg2.setter
     def leg2(self, leg2):
-        self._leg2 = leg2
-
         if leg2:
-            self._h2 = False
-            self._arm2 = False
-            self._leg1 = False
-            self._existingmodule = False
-            self._other = False
+            self.resetallbooleans()
+            self._leg2 = leg2
+
+    @property
+    def lboth(self):
+        if not hasattr(self, '_lboth'):
+            # backward compatibility for attribute added 20250220
+            self._lboth = False
+        return self._lboth
+
+    @lboth.setter
+    def lboth(self, lboth):
+        if lboth:
+            self.resetallbooleans()
+            self._lboth = lboth
 
     @property
     def existingmodule(self):
@@ -1567,14 +1577,9 @@ class RelationY:
 
     @existingmodule.setter
     def existingmodule(self, existingmodule):
-        self._existingmodule = existingmodule
-
         if existingmodule:
-            self._h2 = False
-            self._arm2 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._other = False
+            self.resetallbooleans()
+            self._existingmodule = existingmodule
 
     @property
     def linkedmoduletype(self):
@@ -1601,14 +1606,9 @@ class RelationY:
 
     @other.setter
     def other(self, other):
-        self._other = other
-
         if other:
-            self._h2 = False
-            self._arm2 = False
-            self._leg1 = False
-            self._leg2 = False
-            self._existingmodule = False
+            self.resetallbooleans()
+            self._other = other
 
     @property
     def othertext(self):
@@ -1617,6 +1617,18 @@ class RelationY:
     @othertext.setter
     def othertext(self, othertext):
         self._othertext = othertext
+
+    # helper function for all setters, that resets all boolean attributes to False
+    def resetalltoplevelbooleans(self):
+        self._h2 = False
+        self._arm1 = False
+        self._arm2 = False
+        self._aboth = False
+        self._leg1 = False
+        self._leg2 = False
+        self._lboth = False
+        self._existingmodule = False
+        self._other = False
 
 
 class RelationModule(ParameterModule):
@@ -1763,8 +1775,8 @@ class RelationModule(ParameterModule):
 
     def hands_in_use(self):
         return {
-            1: self.relationx.both or self.relationx.h1,
-            2: self.relationx.both or self.relationx.h2 or self.relationy.h2
+            1: self.relationx.hboth or self.relationx.h1,
+            2: self.relationx.hboth or self.relationx.h2 or self.relationy.h2
         }
 
     def arms_in_use(self):

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -1320,6 +1320,10 @@ class RelationX:
             relX_str = "both hands connected"
         elif self.hboth:
             relX_str = "both hands"
+        elif self.aboth:
+            relX_str = "both arms"
+        elif self.lboth:
+            relX_str = "both legs"
         elif self.other:
             relX_str = "other"
             if len(self.othertext) > 0:
@@ -1467,13 +1471,13 @@ class RelationX:
     def resetalltoplevelbooleans(self):
         self._h1 = False
         self._h2 = False
-        self._hboth = False  # TODO KV changed
+        self._hboth = False
         self._arm1 = False
         self._arm2 = False
-        self._aboth = False  # TODO KV added
+        self._aboth = False
         self._leg1 = False
         self._leg2 = False
-        self._lboth = False  # TODO KV added
+        self._lboth = False
         self._other = False
 
 class RelationY:
@@ -1504,7 +1508,11 @@ class RelationY:
 
     def displaystr(self):
         relY_str = ""
-        if self.existingmodule:
+        if self.aboth:
+            relY_str = "both arms"
+        if self.lboth:
+            relY_str = "both legs"
+        elif self.existingmodule:
             # print(self.linkedmoduleids)
             relY_str = "existing module"
             if self.linkedmoduletype is not None:
@@ -1518,10 +1526,10 @@ class RelationY:
                 relY_str += " (" + self.othertext + ")"
         else:
             rel_dict = self.__dict__
-            for attr in "_h2", "_arm2", "_leg1", "_leg2":
+            for attr in rel_dict:
                 if rel_dict[attr]:
-                    relY_str = attr[1:] # attributes are prepended with _
-                    break    
+                    relY_str = attr[1:]  # attributes are prepended with _
+                    break
         return relY_str
 
     @property
@@ -1823,14 +1831,14 @@ class RelationModule(ParameterModule):
 
     def arms_in_use(self):
         return {
-            1: self.relationx.arm1,
-            2: self.relationx.arm2 or self.relationy.arm2
+            1: self.relationx.aboth or self.relationy.aboth or self.relationx.arm1 or self.relationy.arm1,
+            2: self.relationx.aboth or self.relationy.aboth or self.relationx.arm2 or self.relationy.arm2
         }
 
     def legs_in_use(self):
         return {
-            1: self.relationx.leg1 or self.relationy.leg1,
-            2: self.relationx.leg2 or self.relationy.leg2
+            1: self.relationx.lboth or self.relationy.lboth or self.relationx.leg1 or self.relationy.leg1,
+            2: self.relationx.lboth or self.relationy.lboth or self.relationx.leg2 or self.relationy.leg2
         }
 
     # relation abbreviation
@@ -1842,9 +1850,10 @@ class RelationModule(ParameterModule):
         paths = self.get_paths() 
 
         X_art = self.relationx.displaystr().capitalize()
-        if X_art in ['Both hands', 'Both hands connected']:
+        if X_art.startswith("Both"):
+            art1, art2 = ('H1', 'H2') if "hands" in X_art else (('Arm1', 'Arm2') if "arms" in X_art else ('Leg1', 'Leg2'))
             X_str += f'{X_art}: '
-            X_str += ', '.join([self.get_path_abbrev(paths, a) for a in ['H1', 'H2']])
+            X_str += ', '.join([self.get_path_abbrev(paths, a) for a in [art1, art2]])
         elif X_art.startswith('Other'):
             X_str += X_art
         else:
@@ -1855,11 +1864,13 @@ class RelationModule(ParameterModule):
             Y_str = f'linked {self.relationy.linkedmoduletype} module'
         else:
             Y_art = self.relationy.displaystr().capitalize()
-            if Y_art.startswith('Other'):
+            if Y_art.startswith("Both"):
+                art1, art2 = ('H1', 'H2') if "hands" in Y_art else (('Arm1', 'Arm2') if "arms" in Y_art else ('Leg1', 'Leg2'))
+                Y_str += f'{Y_art}: '
+                Y_str += ', '.join([self.get_path_abbrev(paths, a) for a in [art1, art2]])
+            elif Y_art.startswith('Other'):
                 Y_str += Y_art
             else:
-                Y_art = self.relationy.displaystr().capitalize()
-
                 Y_str = self.get_path_abbrev(paths, Y_art)
 
         X_str = "X = " + X_str

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -1318,7 +1318,7 @@ class RelationX:
         relX_str = ""
         if self.connected:
             relX_str = "both hands connected"
-        elif self.both:
+        elif self.hboth:
             relX_str = "both hands"
         elif self.other:
             relX_str = "other"
@@ -1356,7 +1356,10 @@ class RelationX:
     def hboth(self):
         if not hasattr(self, '_hboth'):
             # backward compatibility for attribute changed 20250220
-            self._hboth = self._both if hasattr(self, '_both') else False
+            self._hboth = False
+            if hasattr(self, '_both'):
+                self._hboth = self._both
+                del self._both
         return self._hboth
 
     @hboth.setter
@@ -1921,6 +1924,7 @@ class RelationModule(ParameterModule):
                 path_str += f'[{", ".join([v if v not in SURFACE_SUBAREA_ABBREVS else SURFACE_SUBAREA_ABBREVS[v] for v in val])}]'
             path_strings.append(path_str)
         return f'{art}[{", ".join(path_strings)}]'
+
 
 class MannerRelation:
     def __init__(self, holding=False, continuous=False, intermittent=False, any=False):


### PR DESCRIPTION
adds to X:
 - both arms
 - both legs

adds to Y:
 - arm 1
 - both arms
 - both legs

rearrange X and Y layouts in relation module dialog

update tooltips when hovering over relation module in sign summary