### PR TITLE
Updated slot style to make the default text colour black

### DIFF
--- a/src/main/python/gui/handconfigspecification_view.py
+++ b/src/main/python/gui/handconfigspecification_view.py
@@ -53,9 +53,14 @@ class ConfigSlot(QLineEdit):
         qss = """   
             QLineEdit {
                 background: white;
+                color: black;
                 text-align: center;
                 margin: 0;
                 padding: 0;
+            }
+
+            QLineEdit:disabled {
+                color: gray;
             }
 
             QLineEdit[AddedInfo=true] {
@@ -183,7 +188,6 @@ class ConfigField(QWidget):
         right_bracket.setFont(bracketfont)
         right_number = QLabel(str(self.field_number))
         right_number.setFont(bracketfont)
-        right_number.setStyleSheet('QLabel{border:1px solid rgb(0, 255, 0);}')
         right_bracket.setFixedSize(QSize(10, 30))
         right_number.setFixedSize(QSize(20, 30))
         right_bracket.setAlignment(Qt.AlignCenter)


### PR DESCRIPTION
- Make the default text colour black for handshape slots, so that it's visible against white background.
- Remove green border for field numbers.