### PR TITLE
make location type buttons deselectable

### DIFF
--- a/src/main/python/gui/locationspecification_view.py
+++ b/src/main/python/gui/locationspecification_view.py
@@ -7,14 +7,12 @@ from PyQt5.QtWidgets import (
     QGraphicsView,
     QGraphicsScene,
     QPushButton,
-    QRadioButton,
     QHBoxLayout,
     QVBoxLayout,
     QGridLayout,
     QComboBox,
     QMessageBox,
     QLabel,
-    QButtonGroup,
     QGroupBox,
     QAbstractItemView,
     QHeaderView,
@@ -45,7 +43,7 @@ from models.location_models import LocationTreeItem, LocationTableModel, Locatio
 from models.shared_models import TreePathsProxyModel
 from serialization_classes import LocationTreeSerializable, LocationTableSerializable
 from gui.modulespecification_widgets import AddedInfoContextMenu, ModuleSpecificationPanel, \
-    TreeListView, TreePathsListItemDelegate, TreeSearchComboBox
+    TreeListView, TreePathsListItemDelegate, TreeSearchComboBox, DeselectableRadioButtonGroup, DeselectableRadioButton
 from constant import CONTRA, IPSI
 
 
@@ -415,7 +413,7 @@ class LocationSpecificationPanel(ModuleSpecificationPanel):
         loctype_layout.addWidget(QLabel("Location:"), alignment=Qt.AlignVCenter)
 
         body_layout = QHBoxLayout()
-        self.body_radio = QRadioButton("Body")
+        self.body_radio = DeselectableRadioButton("Body")
         self.body_radio.setProperty('loctype', 'body')
         body_layout.addWidget(self.body_radio)
         body_layout.addSpacerItem(QSpacerItem(60, 0))  # TODO KV , QSizePolicy.Minimum, QSizePolicy.Maximum))
@@ -425,15 +423,15 @@ class LocationSpecificationPanel(ModuleSpecificationPanel):
 
         signingspace_layout = QGridLayout()
 
-        self.signingspace_radio = QRadioButton("Signing space  (")
+        self.signingspace_radio = DeselectableRadioButton("Signing space  (")
         self.signingspace_radio.setProperty('loctype', 'signingspace')
         signingspace_layout.addWidget(self.signingspace_radio, 0, 0)
 
-        self.signingspacebody_radio = QRadioButton("body-anchored  /")
+        self.signingspacebody_radio = DeselectableRadioButton("body-anchored  /")
         self.signingspacebody_radio.setProperty('loctype', 'signingspace_body')
         signingspace_layout.addWidget(self.signingspacebody_radio, 0, 1)
 
-        self.signingspacespatial_radio = QRadioButton("purely spatial  )")
+        self.signingspacespatial_radio = DeselectableRadioButton("purely spatial  )")
         self.signingspacespatial_radio.setProperty('loctype', 'signingspace_spatial')
         signingspace_layout.addWidget(self.signingspacespatial_radio, 0, 2)
 
@@ -456,10 +454,10 @@ class LocationSpecificationPanel(ModuleSpecificationPanel):
         loctype_layout.addWidget(signingspace_box, alignment=Qt.AlignVCenter)
         loctype_layout.addStretch()
 
-        self.loctype_subgroup = QButtonGroup()
+        self.loctype_subgroup = DeselectableRadioButtonGroup()
         self.loctype_subgroup.addButton(self.body_radio)
         self.loctype_subgroup.addButton(self.signingspace_radio)
-        self.signingspace_subgroup = QButtonGroup()
+        self.signingspace_subgroup = DeselectableRadioButtonGroup()
         self.signingspace_subgroup.addButton(self.signingspacebody_radio)
         self.signingspace_subgroup.addButton(self.signingspacespatial_radio)
         self.loctype_subgroup.buttonToggled.connect(lambda btn, wastoggled:
@@ -605,21 +603,21 @@ class LocationSpecificationPanel(ModuleSpecificationPanel):
             return self.mainwindow.app_settings['location']['default_loctype_2h']
     
     def handle_toggle_locationtype(self, btn):
-        if btn is not None and btn.isChecked():
-            for b in self.signingspace_subgroup.buttons():
-                b.setEnabled(btn == self.signingspace_radio)
-            
-            if self.default_neutral_loctype() == "purely spatial":
-                enable_default_neutral = self.signingspacespatial_radio.isChecked() and self.signingspacespatial_radio.isEnabled()
-            else:
-                enable_default_neutral = self.signingspacebody_radio.isChecked() and self.signingspacebody_radio.isEnabled()
-            self.applyneutral_pb.setEnabled(enable_default_neutral)
-            
-            self.locationoptionsselectionpanel.multiple_selection_cb.setEnabled(
-                self.signingspacespatial_radio.isChecked() == False 
-                or self.signingspacespatial_radio.isEnabled() == False)
+        for b in self.signingspace_subgroup.buttons():
+            b.setEnabled(self.signingspace_radio.isEnabled() and self.signingspace_radio.isChecked())
 
-            self.enablelocationtools()
+        if self.default_neutral_loctype() == "purely spatial":
+            enable_default_neutral = self.signingspacespatial_radio.isChecked() and self.signingspacespatial_radio.isEnabled()
+        else:
+            enable_default_neutral = self.signingspacebody_radio.isChecked() and self.signingspacebody_radio.isEnabled()
+        self.applyneutral_pb.setEnabled(enable_default_neutral)
+
+        self.locationoptionsselectionpanel.multiple_selection_cb.setEnabled(
+            self.signingspacespatial_radio.isChecked() == False
+            or self.signingspacespatial_radio.isEnabled() == False)
+
+        self.enablelocationtools()
+
 
     def enablelocationtools(self):
         # self.refresh_listproxies()

--- a/src/main/python/gui/nonmanualspecification_view.py
+++ b/src/main/python/gui/nonmanualspecification_view.py
@@ -12,29 +12,14 @@ from PyQt5.QtCore import (Qt, pyqtSignal,)
 
 from lexicon.module_classes import NonManualModule
 from models.nonmanual_models import NonManualModel, nonmanual_root
-from gui.relationspecification_view import RelationRadioButton
-from gui.relationspecification_view import RelationButtonGroup
+from gui.modulespecification_widgets import DeselectableRadioButtonGroup, DeselectableRadioButton
 from gui.modulespecification_widgets import ModuleSpecificationPanel
 
 
-class SLPAARadioButton(RelationRadioButton):
-    def __init__(self, text, **kwargs):
-        super().__init__(text, **kwargs)
-
-    def setChecked(self, checked):
-        # override RelationRadioButton's setChecked() method to deal with programmatically unselected btns.
-        if self.group() is not None:
-            if checked:
-                self.group().previously_checked = self
-            else:
-                self.group().previously_checked = None
-        super().setChecked(checked)
-
-
-class MvmtCharRadioButton(SLPAARadioButton):
+class MvmtCharRadioButton(DeselectableRadioButton):
     def __init__(self, text, static_dynamic, **kwargs):
         # buttons for repetition, direction, ... groups (the third row of the spec window)
-        # subclassing SLPAARadioButton for on_toggled() that enable/disable its 'static' button.
+        # subclassing DeselectableRadioButton for on_toggled() that enable/disable its 'static' button.
         super().__init__(text, **kwargs)
 
         self.static_btn = [btn for btn in static_dynamic.buttons() if btn.text() == 'Static'][0]
@@ -47,21 +32,13 @@ class MvmtCharRadioButton(SLPAARadioButton):
             self.dynamic_btn.setChecked(checked)
 
 
-class SLPAAButtonGroup(RelationButtonGroup):
-    def __init__(self, buttonslist=None):
-        # buttonslist: list of QRadioButton to be included as a group
-        super().__init__()
-        if buttonslist is not None:
-            [self.addButton(button) for button in buttonslist]
-
-
 class SpecifyLayout(QHBoxLayout):
     # something like " ○ Other: ________" that consists of radiobutton + lineEdit
     def __init__(self, btn_label, text):
         super().__init__()
         self.setAlignment(Qt.AlignLeft | Qt.AlignTop)
         # radio button
-        self.radio_btn = SLPAARadioButton(btn_label)
+        self.radio_btn = DeselectableRadioButton(btn_label)
         self.radio_btn.toggled.connect(self.radio_button_toggled)
         self.addWidget(self.radio_btn)
 
@@ -499,10 +476,10 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
         row.setAlignment(Qt.AlignTop)
 
         # static / dynamic group
-        nonman.widget_rb_static = SLPAARadioButton("Static")
-        nonman.widget_rb_dynamic = SLPAARadioButton("Dynamic")
+        nonman.widget_rb_static = DeselectableRadioButton("Static")
+        nonman.widget_rb_dynamic = DeselectableRadioButton("Dynamic")
         static_dynamic_list = [nonman.widget_rb_static, nonman.widget_rb_dynamic]
-        nonman.static_dynamic_group = SLPAAButtonGroup(static_dynamic_list)
+        nonman.static_dynamic_group = DeselectableRadioButtonGroup(static_dynamic_list)
 
         vbox = QVBoxLayout()
         vbox.setAlignment(Qt.AlignTop)
@@ -522,7 +499,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
             mvmt_type_box = QGroupBox("Type of mouth movement")
             mvmt_type_box_layout = QVBoxLayout()
             mvmt_type_box.setAlignment(Qt.AlignTop)
-            nonman.mvmt_type_group = SLPAAButtonGroup()
+            nonman.mvmt_type_group = DeselectableRadioButtonGroup()
             for m_type in nonman.subparts:
                 # since all options have the 'specify' line edit, just assume btn + lineEdit
                 rb_label, txt_line = m_type.split(';')
@@ -556,7 +533,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
             description_box = QGroupBox("General description")
             description_box_layout = QVBoxLayout()
             description_box.setAlignment(Qt.AlignTop)
-            nonman.description_group = SLPAAButtonGroup()
+            nonman.description_group = DeselectableRadioButtonGroup()
             for mm_type in nonman.subparts:
                 if ';' in mm_type:
                     mm_type, txt_line = mm_type.split(';')
@@ -566,7 +543,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
                     nonman.widget_le_specify = specify_layout.lineEdit
                     description_box_layout.addLayout(specify_layout)
                 else:
-                    rb_to_add = SLPAARadioButton(mm_type)
+                    rb_to_add = DeselectableRadioButton(mm_type)
                     description_box_layout.addWidget(rb_to_add)
                 nonman.description_group.addButton(rb_to_add)
             description_box.setLayout(description_box_layout)
@@ -589,20 +566,20 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
             onepart_layout = QHBoxLayout()
             onepart_layout.setAlignment(Qt.AlignTop)
 
-            nonman.rb_subpart_both = SLPAARadioButton(f"Both {subpart_specs['specifier']}s")
-            nonman.rb_subpart_one = SLPAARadioButton(f"One {subpart_specs['specifier']}")
+            nonman.rb_subpart_both = DeselectableRadioButton(f"Both {subpart_specs['specifier']}s")
+            nonman.rb_subpart_one = DeselectableRadioButton(f"One {subpart_specs['specifier']}")
             subpart_list = [nonman.rb_subpart_both, nonman.rb_subpart_one]
 
-            nonman.subpart_group = SLPAAButtonGroup(subpart_list)
+            nonman.subpart_group = DeselectableRadioButtonGroup(subpart_list)
 
             nonman.subpart_group.buttonToggled.connect(lambda rb, ischecked:
                                                        self.handle_onepart_btn_toggled(rb, ischecked, nonman))
 
-            rb_onepart_one = SLPAARadioButton("H1")
-            rb_onepart_two = SLPAARadioButton("H2")
+            rb_onepart_one = DeselectableRadioButton("H1")
+            rb_onepart_two = DeselectableRadioButton("H2")
             onepart_list = [rb_onepart_one, rb_onepart_two]
 
-            nonman.onepart_group = SLPAAButtonGroup(onepart_list)  # radiobutton group for H1 and H2
+            nonman.onepart_group = DeselectableRadioButtonGroup(onepart_list)  # radiobutton group for H1 and H2
 
             nonman.onepart_group.buttonToggled.connect(lambda rb, ischecked:
                                                        self.handle_onepart_btn_toggled(rb, ischecked, nonman))
@@ -629,10 +606,10 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
             visibility_box_layout = QVBoxLayout()
             visibility_box_layout.setAlignment(Qt.AlignTop)
 
-            nonman.widget_rb_visible = SLPAARadioButton("Visible")
+            nonman.widget_rb_visible = DeselectableRadioButton("Visible")
             visibility_box_layout.addWidget(nonman.widget_rb_visible)
 
-            nonman.widget_rb_visible_not = SLPAARadioButton("Not visible")
+            nonman.widget_rb_visible_not = DeselectableRadioButton("Not visible")
             visibility_box_layout.addWidget(nonman.widget_rb_visible_not)
 
             visibility_box.setLayout(visibility_box_layout)
@@ -727,7 +704,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
         """
         if isinstance(options, str):
             # in shallow module
-            main_btn = SLPAARadioButton(options)
+            main_btn = DeselectableRadioButton(options)
             parent.as_btn_group.addButton(main_btn)
             parent.widget_grouplayout_actionstate.addWidget(main_btn)
             parent.widget_grouplayout_actionstate.setAlignment(main_btn, Qt.AlignTop)
@@ -738,14 +715,14 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
             # parse this node and its children
             options.widget_grouplayout_actionstate = QVBoxLayout()
             options.widget_grouplayout_actionstate.setAlignment(Qt.AlignTop)
-            options.as_btn_group = SLPAAButtonGroup()  # btn group to contain children
+            options.as_btn_group = DeselectableRadioButtonGroup()  # btn group to contain children
             options.as_cb_list = []  # checkbox list to contain children
 
             main_layout = QVBoxLayout()
             main_layout.setAlignment(Qt.AlignTop)
             if options.exclusive:
                 # create the button itself.
-                options.main_btn = SLPAARadioButton(options.label)
+                options.main_btn = DeselectableRadioButton(options.label)
                 parent.as_btn_group.addButton(options.main_btn)
 
                 # manage button behaviour -- (de)select parent/child as well.
@@ -795,7 +772,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
                             # to reference dynamic btn
                             sub_rb = specify_layout.radio_btn
                         else:
-                            sub_rb = SLPAARadioButton(child)
+                            sub_rb = DeselectableRadioButton(child)
                             sub_layout.addWidget(sub_rb)
                         options.as_btn_group.addButton(sub_rb)
                         sub_spacedlayout.addLayout(sub_layout)
@@ -812,7 +789,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
             # in the root. be ready to go deeper
             options.widget_grouplayout_actionstate = QHBoxLayout()
             options.widget_grouplayout_actionstate.setAlignment(Qt.AlignTop)
-            options.as_btn_group = SLPAAButtonGroup()
+            options.as_btn_group = DeselectableRadioButtonGroup()
             options.as_cb_list = []
             for child in options.options:
                 self.parse_actionstate(parent=options,
@@ -853,7 +830,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
             widget_rb_rep_trill = MvmtCharRadioButton("Trilled", nonman.static_dynamic_group)
             rep_btn_list = [widget_rb_rep_single, nonman.layout_repetition.repeated_btn, widget_rb_rep_trill]
 
-            nonman.repetition_group = SLPAAButtonGroup(rep_btn_list)
+            nonman.repetition_group = DeselectableRadioButtonGroup(rep_btn_list)
 
             repetition_group_layout.addWidget(widget_rb_rep_single)
             repetition_group_layout.addLayout(nonman.layout_repetition)
@@ -873,7 +850,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
                                                                 static_dynamic=nonman.static_dynamic_group)
             directionality_list = [nonman.widget_rb_direction_uni, nonman.widget_rb_direction_bi]
 
-            nonman.directionality_group = SLPAAButtonGroup(directionality_list)
+            nonman.directionality_group = DeselectableRadioButtonGroup(directionality_list)
 
             [directionality_group_layout.addWidget(widget) for widget in directionality_list]
             directionality_group.setLayout(directionality_group_layout)
@@ -907,7 +884,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
                              nonman.widget_rb_eyegazedistance_normal,
                              nonman.widget_rb_eyegazedistance_proximal]
 
-            nonman.distance_group = SLPAAButtonGroup(distance_list)
+            nonman.distance_group = DeselectableRadioButtonGroup(distance_list)
 
             [distance_layout.addWidget(widget) for widget in distance_list]
             distance_group.setLayout(distance_layout)
@@ -929,7 +906,7 @@ class NonManualSpecificationPanel(ModuleSpecificationPanel):
         for group, levels in specs.items():
             groupbox = QGroupBox(group)
             groupbox_layout = QVBoxLayout()
-            buttongroup = SLPAAButtonGroup()
+            buttongroup = DeselectableRadioButtonGroup()
 
             levels.insert(1, 'Normal')
 
@@ -1379,7 +1356,7 @@ def get_value_from_saved_dict(key_to_find, input_dict, parent=None):
 
 
 def what_selected(group):
-    # input: SLPAAButtonGroup or list of QCheckBox objects
+    # input: DeselectableRadioButtonGroup or list of QCheckBox objects
     # helper function to get what user input among buttons/checkboxes in the group
     if isinstance(group, QButtonGroup):
         # get selected button (exclusive)
@@ -1392,8 +1369,8 @@ def what_selected(group):
 
 
 def select_this(btn_group, btn_txt):
-    # given SLPAAButtonGroup, select the button named 'btn_txt'
-    if not isinstance(btn_group, SLPAAButtonGroup):
+    # given DeselectableRadioButtonGroup, select the button named 'btn_txt'
+    if not isinstance(btn_group, DeselectableRadioButtonGroup):
         return None
 
     if btn_txt is None:

--- a/src/main/python/gui/relationspecification_view.py
+++ b/src/main/python/gui/relationspecification_view.py
@@ -1,7 +1,6 @@
 from PyQt5.QtWidgets import (
     QListView,
     QLineEdit,
-    QRadioButton,
     QHBoxLayout,
     QVBoxLayout,
     QLabel,
@@ -34,7 +33,8 @@ from lexicon.module_classes import (
 )
 from models.relation_models import ModuleLinkingListModel
 from models.location_models import BodypartTreeModel
-from gui.modulespecification_widgets import ModuleSpecificationPanel, SpecifyBodypartPushButton
+from gui.modulespecification_widgets import ModuleSpecificationPanel, SpecifyBodypartPushButton, \
+    DeselectableRadioButtonGroup, DeselectableRadioButton
 from gui.bodypartspecification_dialog import BodypartSelectorDialog
 from gui.helper_widget import OptionSwitch
 from constant import HAND, ARM, LEG, ModuleTypes
@@ -146,10 +146,10 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         # create layout for horizontal distance options
         self.dishor_box = QGroupBox()
         self.dishor_label = QLabel("Horizontal")
-        self.dishorclose_rb = RelationRadioButton("Close")
-        self.dishormed_rb = RelationRadioButton("Med.")
-        self.dishorfar_rb = RelationRadioButton("Far")
-        self.dishor_group = RelationButtonGroup()
+        self.dishorclose_rb = DeselectableRadioButton("Close")
+        self.dishormed_rb = DeselectableRadioButton("Med.")
+        self.dishorfar_rb = DeselectableRadioButton("Far")
+        self.dishor_group = DeselectableRadioButtonGroup()
         self.dishor_group.buttonToggled.connect(self.handle_distancebutton_toggled)
         dis_hor_layout = self.create_axis_layout(self.dishorclose_rb,
                                                  self.dishormed_rb,
@@ -162,10 +162,10 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         # create layout for vertical distance options
         self.disver_box = QGroupBox()
         self.disver_label = QLabel("Vertical")
-        self.disverclose_rb = RelationRadioButton("Close")
-        self.disvermed_rb = RelationRadioButton("Med.")
-        self.disverfar_rb = RelationRadioButton("Far")
-        self.disver_group = RelationButtonGroup()
+        self.disverclose_rb = DeselectableRadioButton("Close")
+        self.disvermed_rb = DeselectableRadioButton("Med.")
+        self.disverfar_rb = DeselectableRadioButton("Far")
+        self.disver_group = DeselectableRadioButtonGroup()
         self.disver_group.buttonToggled.connect(self.handle_distancebutton_toggled)
         dis_ver_layout = self.create_axis_layout(self.disverclose_rb,
                                                  self.disvermed_rb,
@@ -178,10 +178,10 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         # create layout for sagittal distance options
         self.dissag_box = QGroupBox()
         self.dissag_label = QLabel("Sagittal")
-        self.dissagclose_rb = RelationRadioButton("Close")
-        self.dissagmed_rb = RelationRadioButton("Med.")
-        self.dissagfar_rb = RelationRadioButton("Far")
-        self.dissag_group = RelationButtonGroup()
+        self.dissagclose_rb = DeselectableRadioButton("Close")
+        self.dissagmed_rb = DeselectableRadioButton("Med.")
+        self.dissagfar_rb = DeselectableRadioButton("Far")
+        self.dissag_group = DeselectableRadioButtonGroup()
         self.dissag_group.buttonToggled.connect(self.handle_distancebutton_toggled)
         dis_sag_layout = self.create_axis_layout(self.dissagclose_rb,
                                                  self.dissagmed_rb,
@@ -193,10 +193,10 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         # create layout for generic distance options
         self.disgen_box = QGroupBox()
         self.disgen_label = QLabel("Generic")
-        self.disgenclose_rb = RelationRadioButton("Close")
-        self.disgenmed_rb = RelationRadioButton("Med.")
-        self.disgenfar_rb = RelationRadioButton("Far")
-        self.disgen_group = RelationButtonGroup()
+        self.disgenclose_rb = DeselectableRadioButton("Close")
+        self.disgenmed_rb = DeselectableRadioButton("Med.")
+        self.disgenfar_rb = DeselectableRadioButton("Far")
+        self.disgen_group = DeselectableRadioButtonGroup()
         self.disgen_group.buttonToggled.connect(self.handle_distancebutton_toggled)
         dis_gen_layout = self.create_axis_layout(self.disgenclose_rb,
                                                  self.disgenmed_rb,
@@ -344,10 +344,10 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         # create layout for horizontal direction options
         self.dirhor_box = QGroupBox()
         self.dirhor_cb = QCheckBox("Horizontal")
-        self.dirhoripsi_rb = RelationRadioButton("X ipsilateral to Y")
-        self.dirhorcontra_rb = RelationRadioButton("X contralateral to Y")
-        self.dirhorinline_rb = RelationRadioButton("X in line with Y")
-        self.dirhor_group = RelationButtonGroup()
+        self.dirhoripsi_rb = DeselectableRadioButton("X ipsilateral to Y")
+        self.dirhorcontra_rb = DeselectableRadioButton("X contralateral to Y")
+        self.dirhorinline_rb = DeselectableRadioButton("X in line with Y")
+        self.dirhor_group = DeselectableRadioButtonGroup()
         dir_hor_layout = self.create_axis_layout(self.dirhoripsi_rb,
                                                  self.dirhorcontra_rb,
                                                  self.dirhorinline_rb,
@@ -359,10 +359,10 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         # create layout for vertical direction options
         self.dirver_box = QGroupBox()
         self.dirver_cb = QCheckBox("Vertical")
-        self.dirverabove_rb = RelationRadioButton("X above Y")
-        self.dirverbelow_rb = RelationRadioButton("X below Y")
-        self.dirverinline_rb = RelationRadioButton("X in line with Y")
-        self.dirver_group = RelationButtonGroup()
+        self.dirverabove_rb = DeselectableRadioButton("X above Y")
+        self.dirverbelow_rb = DeselectableRadioButton("X below Y")
+        self.dirverinline_rb = DeselectableRadioButton("X in line with Y")
+        self.dirver_group = DeselectableRadioButtonGroup()
         dir_ver_layout = self.create_axis_layout(self.dirverabove_rb,
                                                  self.dirverbelow_rb,
                                                  self.dirverinline_rb,
@@ -374,10 +374,10 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         # create layout for sagittal direction options
         self.dirsag_box = QGroupBox()
         self.dirsag_cb = QCheckBox("Sagittal")
-        self.dirsagdist_rb = RelationRadioButton("X distal to Y")
-        self.dirsagprox_rb = RelationRadioButton("X proximal to Y")
-        self.dirsaginline_rb = RelationRadioButton("X in line with Y")
-        self.dirsag_group = RelationButtonGroup()
+        self.dirsagdist_rb = DeselectableRadioButton("X distal to Y")
+        self.dirsagprox_rb = DeselectableRadioButton("X proximal to Y")
+        self.dirsaginline_rb = DeselectableRadioButton("X in line with Y")
+        self.dirsag_group = DeselectableRadioButtonGroup()
         dir_sag_layout = self.create_axis_layout(self.dirsagdist_rb,
                                                  self.dirsagprox_rb,
                                                  self.dirsaginline_rb,
@@ -406,17 +406,17 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         contact_layout = QVBoxLayout()
         contacttype_spacedlayout = QHBoxLayout()
 
-        self.contact_rb = RelationRadioButton("Contact")
-        self.nocontact_rb = RelationRadioButton("No contact")
-        self.contact_group = RelationButtonGroup()
+        self.contact_rb = DeselectableRadioButton("Contact")
+        self.nocontact_rb = DeselectableRadioButton("No contact")
+        self.contact_group = DeselectableRadioButtonGroup()
         self.contact_group.addButton(self.contact_rb)
         self.contact_group.addButton(self.nocontact_rb)
         self.contact_group.buttonToggled.connect(self.handle_contactgroup_toggled)
 
-        self.contactlight_rb = RelationRadioButton("Light")
-        self.contactfirm_rb = RelationRadioButton("Firm")
-        self.contactother_rb = RelationRadioButton("Other")
-        self.contacttype_group = RelationButtonGroup()
+        self.contactlight_rb = DeselectableRadioButton("Light")
+        self.contactfirm_rb = DeselectableRadioButton("Firm")
+        self.contactother_rb = DeselectableRadioButton("Other")
+        self.contacttype_group = DeselectableRadioButtonGroup()
         self.contacttype_group.addButton(self.contactlight_rb)
         self.contacttype_group.addButton(self.contactfirm_rb)
         self.contacttype_group.addButton(self.contactother_rb)
@@ -492,10 +492,10 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
     # create layout for specifying contact manner
     def create_manner_box(self):
         manner_box = QGroupBox("Contact manner")
-        self.holding_rb = RelationRadioButton("Holding")
-        self.continuous_rb = RelationRadioButton("Continuous")
-        self.intermittent_rb = RelationRadioButton("Intermittent")
-        self.manner_group = RelationButtonGroup()
+        self.holding_rb = DeselectableRadioButton("Holding")
+        self.continuous_rb = DeselectableRadioButton("Continuous")
+        self.intermittent_rb = DeselectableRadioButton("Intermittent")
+        self.manner_group = DeselectableRadioButtonGroup()
         self.manner_group.buttonToggled.connect(self.handle_mannerbutton_toggled)
         self.manner_group.addButton(self.holding_rb)
         self.manner_group.addButton(self.continuous_rb)
@@ -733,18 +733,18 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
         x_layout_handsconnected = QHBoxLayout()
         self.x_group = QButtonGroup()
         self.x_group.buttonToggled.connect(self.handle_xgroup_toggled)
-        self.x_h1_radio = RelationRadioButton("H1")
-        self.x_h2_radio = RelationRadioButton("H2")
-        self.x_hboth_radio = RelationRadioButton("Both hands")
+        self.x_h1_radio = DeselectableRadioButton("H1")
+        self.x_h2_radio = DeselectableRadioButton("H2")
+        self.x_hboth_radio = DeselectableRadioButton("Both hands")
         self.x_hbothconnected_cb = QCheckBox("As a connected unit")
         self.x_hbothconnected_cb.toggled.connect(self.handle_xconnected_toggled)
-        self.x_a1_radio = RelationRadioButton("Arm1")
-        self.x_a2_radio = RelationRadioButton("Arm2")
-        self.x_aboth_radio = RelationRadioButton("Both arms")
-        self.x_l1_radio = RelationRadioButton("Leg1")
-        self.x_l2_radio = RelationRadioButton("Leg2")
-        self.x_lboth_radio = RelationRadioButton("Both legs")
-        self.x_other_radio = RelationRadioButton("Other")
+        self.x_a1_radio = DeselectableRadioButton("Arm1")
+        self.x_a2_radio = DeselectableRadioButton("Arm2")
+        self.x_aboth_radio = DeselectableRadioButton("Both arms")
+        self.x_l1_radio = DeselectableRadioButton("Leg1")
+        self.x_l2_radio = DeselectableRadioButton("Leg2")
+        self.x_lboth_radio = DeselectableRadioButton("Both legs")
+        self.x_other_radio = DeselectableRadioButton("Other")
         self.x_other_text = QLineEdit()
         self.x_other_text.setPlaceholderText("Specify")
         self.x_other_text.textEdited.connect(lambda txt: self.handle_othertext_edited(txt, self.x_other_radio))
@@ -851,17 +851,17 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
 
         self.y_group = QButtonGroup()
         self.y_group.buttonToggled.connect(self.handle_ygroup_toggled)
-        self.y_h2_radio = RelationRadioButton("H2")
-        self.y_a1_radio = RelationRadioButton("Arm1")
-        self.y_a2_radio = RelationRadioButton("Arm2")
-        self.y_aboth_radio = RelationRadioButton("Both arms")
-        self.y_l1_radio = RelationRadioButton("Leg1")
-        self.y_l2_radio = RelationRadioButton("Leg2")
-        self.y_lboth_radio = RelationRadioButton("Both legs")
-        self.y_existingmod_radio = RelationRadioButton("Existing module:")
+        self.y_h2_radio = DeselectableRadioButton("H2")
+        self.y_a1_radio = DeselectableRadioButton("Arm1")
+        self.y_a2_radio = DeselectableRadioButton("Arm2")
+        self.y_aboth_radio = DeselectableRadioButton("Both arms")
+        self.y_l1_radio = DeselectableRadioButton("Leg1")
+        self.y_l2_radio = DeselectableRadioButton("Leg2")
+        self.y_lboth_radio = DeselectableRadioButton("Both legs")
+        self.y_existingmod_radio = DeselectableRadioButton("Existing module:")
         self.y_existingmod_switch = OptionSwitch("Location", "Movement")
 
-        self.y_other_radio = RelationRadioButton("Other")
+        self.y_other_radio = DeselectableRadioButton("Other")
         self.y_other_text = QLineEdit()
         self.y_other_text.setPlaceholderText("Specify")
         self.y_other_text.textEdited.connect(lambda txt: self.handle_othertext_edited(txt, self.y_other_radio))
@@ -1388,40 +1388,3 @@ class RelationSpecificationPanel(ModuleSpecificationPanel):
     def desiredheight(self):
         return 700
 
-
-# this radio button class tracks not only its current state
-#   (and, as usual, mutual exclusivity with buttons in the same group)
-#   but also, when a group button is toggled, updates the group with its identity
-#   for the purposes of being able to un-check when appropriate
-class RelationRadioButton(QRadioButton):
-
-    def __init__(self, text, **kwargs):
-        super().__init__(text, **kwargs)
-
-    def setChecked(self, checked):
-        if checked and self.group() is not None:
-            self.group().previously_checked = self
-        super().setChecked(checked)
-
-
-# this buttongroup allows for unchecking buttons even when the group is set to mutually exclusive
-class RelationButtonGroup(QButtonGroup):
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        # in order to compare new checked button with previously-checked button
-        self.previously_checked = None
-
-        self.buttonClicked.connect(self.handle_button_clicked)
-
-    def handle_button_clicked(self, btn):
-        if self.previously_checked == btn:
-            # user clicked an already-selected button; we'll uncheck it
-            self.setExclusive(False)
-            btn.setChecked(False)
-            self.setExclusive(True)
-            self.previously_checked = None
-        else:
-            # user clicked a previously-unselected button
-            self.previously_checked = btn

--- a/src/main/python/search/search_classes.py
+++ b/src/main/python/search/search_classes.py
@@ -40,7 +40,8 @@ from PyQt5.QtWidgets import (
 from gui.movementspecification_view import MovementSpecificationPanel
 from gui.locationspecification_view import LocationSpecificationPanel
 from gui.handconfigspecification_view import HandConfigSpecificationPanel
-from gui.relationspecification_view import RelationSpecificationPanel, RelationRadioButton, RelationButtonGroup, ModuleLinkingListModel
+from gui.relationspecification_view import RelationSpecificationPanel, ModuleLinkingListModel
+from gui.modulespecification_widgets import DeselectableRadioButton, DeselectableRadioButtonGroup
 from gui.modulespecification_dialog import XslotLinkingPanel, XslotLinkScene, AssociatedRelationsDialog, AssociatedRelationsPanel
 from gui.modulespecification_widgets import AddedInfoPushButton, ArticulatorSelector
 
@@ -825,11 +826,11 @@ class Search_RelationSpecPanel(RelationSpecificationPanel):
         # create layout for horizontal distance options
         self.dishor_box = QGroupBox()
         self.dishor_label = QLabel("Horizontal")
-        self.dishorclose_rb = RelationRadioButton("Close")
-        self.dishormed_rb = RelationRadioButton("Med.")
-        self.dishorfar_rb = RelationRadioButton("Far")
+        self.dishorclose_rb = DeselectableRadioButton("Close")
+        self.dishormed_rb = DeselectableRadioButton("Med.")
+        self.dishorfar_rb = DeselectableRadioButton("Far")
         self.dishor_cb = QCheckBox(self.dishor_label.text())
-        self.dishor_group = RelationButtonGroup()
+        self.dishor_group = DeselectableRadioButtonGroup()
         self.dishor_group.buttonToggled.connect(self.handle_distancebutton_toggled)
         dis_hor_layout = self.create_axis_layout(self.dishorclose_rb,
                                                  self.dishormed_rb,
@@ -843,11 +844,11 @@ class Search_RelationSpecPanel(RelationSpecificationPanel):
         # create layout for vertical distance options
         self.disver_box = QGroupBox()
         self.disver_label = QLabel("Vertical")
-        self.disverclose_rb = RelationRadioButton("Close")
-        self.disvermed_rb = RelationRadioButton("Med.")
-        self.disverfar_rb = RelationRadioButton("Far")
+        self.disverclose_rb = DeselectableRadioButton("Close")
+        self.disvermed_rb = DeselectableRadioButton("Med.")
+        self.disverfar_rb = DeselectableRadioButton("Far")
         self.disver_cb = QCheckBox(self.disver_label.text())
-        self.disver_group = RelationButtonGroup()
+        self.disver_group = DeselectableRadioButtonGroup()
         self.disver_group.buttonToggled.connect(self.handle_distancebutton_toggled)
         dis_ver_layout = self.create_axis_layout(self.disverclose_rb,
                                                  self.disvermed_rb,
@@ -861,11 +862,11 @@ class Search_RelationSpecPanel(RelationSpecificationPanel):
         # create layout for sagittal direction options
         self.dissag_box = QGroupBox()
         self.dissag_label = QLabel("Sagittal")
-        self.dissagclose_rb = RelationRadioButton("Close")
-        self.dissagmed_rb = RelationRadioButton("Med.")
-        self.dissagfar_rb = RelationRadioButton("Far")
+        self.dissagclose_rb = DeselectableRadioButton("Close")
+        self.dissagmed_rb = DeselectableRadioButton("Med.")
+        self.dissagfar_rb = DeselectableRadioButton("Far")
         self.dissag_cb = QCheckBox(self.dissag_label.text())
-        self.dissag_group = RelationButtonGroup()
+        self.dissag_group = DeselectableRadioButtonGroup()
         self.dissag_group.buttonToggled.connect(self.handle_distancebutton_toggled)
         dis_sag_layout = self.create_axis_layout(self.dissagclose_rb,
                                                  self.dissagmed_rb,
@@ -878,11 +879,11 @@ class Search_RelationSpecPanel(RelationSpecificationPanel):
         # create layout for generic distance options
         self.disgen_box = QGroupBox()
         self.disgen_label = QLabel("Generic")
-        self.disgenclose_rb = RelationRadioButton("Close")
-        self.disgenmed_rb = RelationRadioButton("Med.")
-        self.disgenfar_rb = RelationRadioButton("Far")
+        self.disgenclose_rb = DeselectableRadioButton("Close")
+        self.disgenmed_rb = DeselectableRadioButton("Med.")
+        self.disgenfar_rb = DeselectableRadioButton("Far")
         self.disgen_cb = QCheckBox(self.disgen_label.text())
-        self.disgen_group = RelationButtonGroup()
+        self.disgen_group = DeselectableRadioButtonGroup()
         self.disgen_group.buttonToggled.connect(self.handle_distancebutton_toggled)
         dis_gen_layout = self.create_axis_layout(self.disgenclose_rb,
                                                  self.disgenmed_rb,
@@ -1081,7 +1082,6 @@ class Search_AssociatedRelationsPanel(AssociatedRelationsPanel):
         associatedrelations_dialog.module_saved.connect(self.module_saved.emit)
         associatedrelations_dialog.exec_()
         self.style_seeassociatedrelations()  # in case one/some were deleted and there are none left now
-
 
 
     def check_enable_saveaddrelation(self, hastiming=None, hasarticulators=None, bodyloc=None):


### PR DESCRIPTION
Also involves refactoring deselectable radio button / buttongroup classes from relation module to a more generally accessible spot. These classes are also referenced by nonmanual module and relation search target.