### PR TITLE
469 negative searches for movement

### DIFF
--- a/src/main/python/search/helper_functions.py
+++ b/src/main/python/search/helper_functions.py
@@ -364,26 +364,30 @@ def filter_modules_by_target_mvmt(modulelist, target_module, target_paths:set=No
         If `terminate_early` is True and target paths are specified, the list contains only the first module in `modulelist` that matches `target_module`. 
         If matchtype is `exact`, matching modules cannot contain any details or selections not specified in `target_module`.
     """ 
+    if not modulelist:
+        return []
     for filter in [filter_modules_by_articulators, filter_modules_by_phonlocs]:
         modulelist = filter(modulelist, target_module, matchtype)
-        if not matching_modules:
+        if not modulelist:
             return []
+
+    # TODO filter by xslot types! 
 
     # Filter for modules that match target paths
     target_paths = target_paths or set(target_module.movementtreemodel.get_checked_items())
-    # for m in matching_modules:
-    # if matchtype == 'exact':
-    #     if terminate_early:
-    #         pass
-    if target_paths:
-        # TODO matching_modules = m for m in ... if module_matches_xslottype(module.timingintervals, target_module.timingintervals, xslottype, sign.xslotstructure, self.matchtype):
-        # TODO minimal vs exact, and terminate_early
-        matching_modules = [m for m in matching_modules if target_paths.issubset(set(m.movementtreemodel.get_checked_items()))]
-        
-        if not matching_modules: return []
-                
-    return matching_modules
+    if terminate_early:
+        for m in modulelist:
+            module_paths = set(m.movementtreemodel.get_checked_items())
+            if ((matchtype == "exact" and module_paths == target_paths) 
+                or (matchtype == "minimal" and target_paths.issubset(module_paths))):
+                return [m]
+    elif matchtype == "exact":
+        return [m for m in modulelist if set(m.movementtreemodel.get_checked_items()) == target_paths]
+    elif matchtype == "minimal":
+        return [m for m in modulelist if target_paths.issubset(set(m.movementtreemodel.get_checked_items()))]
+            
 
+                
 def filter_modules_by_target_locn(modulelist, target_module, matchtype='minimal', terminate_early=False): 
     """
     Filter a list of location modules, returning a subset that matches a target location module.

--- a/src/main/python/search/search_builder.py
+++ b/src/main/python/search/search_builder.py
@@ -1,6 +1,6 @@
 from fractions import Fraction
 
-import io, os, pickle
+import io, os, pickle, time
 from PyQt5.QtGui import (
     QIcon,
     QKeySequence
@@ -216,10 +216,13 @@ class SearchWindow(QMainWindow):
             self.searchmodel.searchtype = type
             self.searchmodel.matchtype = self.search_params_view.match_type
             self.searchmodel.matchdegree = self.search_params_view.match_degree
-
+            # start_time = time.time()
             resultsdict = self.searchmodel.search_corpus(self.corpus)
             self.results_view = ResultsView(resultsdict, mainwindow=self)
             self.results_view.show()
+            # end_time = time.time()
+            # elapsed_time = end_time - start_time
+            # print(f"Elapsed time: {elapsed_time} seconds")
         
 
 

--- a/src/main/python/search/search_models.py
+++ b/src/main/python/search/search_models.py
@@ -19,7 +19,7 @@ from lexicon.module_classes import (AddedInfo, TimingInterval, TimingPoint, Para
                                     ModuleTypes, BodypartInfo, MovementModule, LocationModule, RelationModule,
                                     HandConfigurationHand, PREDEFINED_MAP)
 from constant import TargetTypes, HAND, ARM, LEG, HandConfigSlots
-import logging
+import logging, time
 
 from models.movement_models import MovementTreeModel
 from models.location_models import LocationTreeModel, BodypartTreeModel
@@ -27,7 +27,8 @@ from serialization_classes import LocationModuleSerializable, MovementModuleSeri
 from search.helper_functions import *
 from search.search_classes import SearchTargetItem
 
-
+class Precomputed:
+    MOV_PATHS = 'mvmt paths' 
 
 
 class TargetHeaders:
@@ -141,13 +142,29 @@ class SearchModel(QStandardItemModel):
             if self.is_included(row):
                 rows.append(row)
         return rows
+    
+    def precompute_targets(self, selected_rows):
+        # TODO potentially update each time a new target is created.
+        # we pre-compute some things such as movement and location paths
+        # to avoid re-computing them each time we call a filter or sign_matches_ function
+        # Done so far: movement paths
+        
+        self.precomputed_targets = {} # reset
+        for row in selected_rows:
+            if self.target_type(row) == ModuleTypes.MOVEMENT:
+                module = self.target_module(row)
+                self.precomputed_targets[row] = {Precomputed.MOV_PATHS: set(module.movementtreemodel.get_checked_items())}
+            
+        
+        
 
     def search_corpus(self, corpus): # TODO potentially add a rows_to_skip for adding on to existing results table
         corpusname = os.path.split(corpus.path)[1]
         selected_rows = self.get_selected_rows()       
+        self.precompute_targets(selected_rows)
         resultsdict = {}
         
-
+        
         if self.matchdegree == 'all':
             # Create a dictionary to store like targets together. Keys are target type, values are lists containing row numbers.
             negative_rows = [] 
@@ -329,10 +346,15 @@ class SearchModel(QStandardItemModel):
            
         modules_to_check = [m for m in sign.getmoduledict(ModuleTypes.MOVEMENT).values()]
         for row in rows:
+            target_module = self.target_module(row)
+            if row in self.precomputed_targets:
+                target_paths = self.precomputed_targets[row][Precomputed.MOV_PATHS]
+            else:
+                target_paths = set(target_module.movementtreemodel.get_checked_items())
+            
             # if negative ("match signs not containing path xyz"), stop as soon as we find a module containing path xyz
             terminate_early = True if self.is_negative(row) else False 
-            target_module = self.target_module(row)
-            target_paths = set(target_module.movementtreemodel.get_checked_items())
+            
             matching_modules = filter_modules_by_target_mvmt(modules_to_check, target_module, target_paths, matchtype=self.matchtype, terminate_early=terminate_early)
             if not (self.is_negative(row) ^ bool(matching_modules)):
                 return False


### PR DESCRIPTION
Fully implemented minimal/exact and positive/negative searches for Movement.

Also, added a function to pre-compute and store certain target features before searching. This should significantly decrease search time for large corpora. For now, only movement paths are pre-computed.