### PR TITLE
display sign type abbreviations for hand, arm, leg in uppercase (eg 2L) instead of lowercase (eg 2l)

### DIFF
--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -1301,7 +1301,9 @@ class Signtype:
             abbrevlist = []
             abbrevstr = ""
             for k in abbrevsdict.keys():
-                abbrevlist.append(k + self.makeabbreviationstring(abbrevsdict[k]))
+                isarticulatorabbr = re.match('^[12][hal]$', k)
+                k_display = k.upper() if isarticulatorabbr else k
+                abbrevlist.append(k_display + self.makeabbreviationstring(abbrevsdict[k]))
             abbrevstr += "; ".join(abbrevlist)
             return " (" + abbrevstr + ")"
 


### PR DESCRIPTION
Changed display text but not underlying text strings, since those are hard coded and used for determining sign type button properties.