### PR TITLE
488 include forearm flag (field 1) in abbreviation for handconfiguration module

### DIFF
--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -2844,7 +2844,6 @@ class HandConfigurationModule(ParameterModule):
 
         forearm = "+ forearm" if self.overalloptions['forearm'] else ""
 
-        print(predefinedname + fieldstext + forearm)
         return predefinedname + fieldstext + forearm
 
         

--- a/src/main/python/lexicon/module_classes.py
+++ b/src/main/python/lexicon/module_classes.py
@@ -2826,8 +2826,6 @@ class HandConfigurationModule(ParameterModule):
             return True
         return False
 
-
-
     def getabbreviation(self):
         handconfighand = HandConfigurationHand(self.handconfiguration)
 
@@ -2844,7 +2842,10 @@ class HandConfigurationModule(ParameterModule):
                 fieldstext += slot.symbol
             fieldstext += "] "
 
-        return predefinedname + fieldstext
+        forearm = "+ forearm" if self.overalloptions['forearm'] else ""
+
+        print(predefinedname + fieldstext + forearm)
+        return predefinedname + fieldstext + forearm
 
         
 # This class consists of six fields (2 through 7; 1 is forearm and is not included here) that store


### PR DESCRIPTION
HandConfiguration abbreviations (used in tooltips, search target descriptions, etc) now include a potential "+ forearm" suffix, iff field 1 is checked in the handconfig module specification dialog.